### PR TITLE
Move to `github.com/openshift-online`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ antlr_sum:=6852386d7975eff29171dae002cc223251510d35f291ae277948f381a7b380b4
 
 # Details of the model to use:
 model_version:=v0.0.1
-model_url:=https://gitlab.cee.redhat.com/service/ocm-api-model.git
+model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 .PHONY: cmds
 cmds: generate
@@ -61,7 +61,7 @@ unit_tests:
 model_tests: cmds model
 	./ocm-metamodel-tool generate \
 		--model=model/model \
-		--base=gitlab.cee.redhat.com/service/ocm-api-metamodel/tests/api \
+		--base=github.com/openshift-online/ocm-api-metamodel/tests/api \
 		--output=tests/api \
 		--docs=tests/docs
 	ginkgo -r tests

--- a/cmd/ocm-metamodel-tool/generate/cmd.go
+++ b/cmd/ocm-metamodel-tool/generate/cmd.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/generators"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/language"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/generators"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // Cmd is the dt definition of the command:

--- a/cmd/ocm-metamodel-tool/main.go
+++ b/cmd/ocm-metamodel-tool/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/cmd/ocm-metamodel-tool/generate"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/cmd/ocm-metamodel-tool/version"
+	"github.com/openshift-online/ocm-api-metamodel/cmd/ocm-metamodel-tool/generate"
+	"github.com/openshift-online/ocm-api-metamodel/cmd/ocm-metamodel-tool/version"
 )
 
 // Root command:

--- a/cmd/ocm-metamodel-tool/version/cmd.go
+++ b/cmd/ocm-metamodel-tool/version/cmd.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/info"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/info"
 )
 
 var Cmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab.cee.redhat.com/service/ocm-api-metamodel
+module github.com/openshift-online/ocm-api-metamodel
 
 go 1.12
 

--- a/pkg/asciidoc/buffer.go
+++ b/pkg/asciidoc/buffer.go
@@ -26,7 +26,7 @@ import (
 	"text/template"
 	"unicode"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // BufferBuilder is used to create a new Asciidoc buffer. Don't create it directly, use the

--- a/pkg/asciidoc/names.go
+++ b/pkg/asciidoc/names.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // NamesCalculatorBuilder is an object used to configure and build the Asciidoc names calculators.

--- a/pkg/concepts/attribute.go
+++ b/pkg/concepts/attribute.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Attribute is the representation of an attribute of an structured type.

--- a/pkg/concepts/error.go
+++ b/pkg/concepts/error.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Error is the representation of a catagery of errors.

--- a/pkg/concepts/locator.go
+++ b/pkg/concepts/locator.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Locator represents a resource locator, the reference from a resource to another resource.

--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Method represents a method of a resource.

--- a/pkg/concepts/model.go
+++ b/pkg/concepts/model.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Model is the representation of the set of services, each with a set of versions.

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Parameter represents a parameter of a method.

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Resource represents an API resource.

--- a/pkg/concepts/service.go
+++ b/pkg/concepts/service.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // Service is the representation of service, containing potentiall mutiple versions, for example the

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 // TypeKind specifies the kind of a type. It can be scalar, enum, struct, list or class.

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -17,8 +17,8 @@ limitations under the License.
 package concepts
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
 )
 
 // Version is the representation of a version of a service.

--- a/pkg/generators/builders.go
+++ b/pkg/generators/builders.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // BuildersGeneratorBuilder is an object used to configure and build the builders generator. Don't

--- a/pkg/generators/clients.go
+++ b/pkg/generators/clients.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"path"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // ClientsGeneratorBuilder is an object used to configure and build a client generator. Don't create

--- a/pkg/generators/docs.go
+++ b/pkg/generators/docs.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strings"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/asciidoc"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/asciidoc"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // DocsGeneratorBuilder is an object used to configure and build the builders generator. Don't

--- a/pkg/generators/readers.go
+++ b/pkg/generators/readers.go
@@ -21,11 +21,11 @@ import (
 	"path"
 	"path/filepath"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // ReadersGeneratorBuilder is an object used to configure and build the JSON readers generator.

--- a/pkg/generators/servers.go
+++ b/pkg/generators/servers.go
@@ -22,11 +22,11 @@ import (
 	"path"
 	"path/filepath"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // ServersGeneratorBuilder is an object used to configure and build the servers generator. Don't create

--- a/pkg/generators/types.go
+++ b/pkg/generators/types.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/golang"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // TypesGeneratorBuilder is an object used to configure and build the types generator. Don't create

--- a/pkg/golang/buffer.go
+++ b/pkg/golang/buffer.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"text/template"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // BufferBuilder is used to create a new Go buffer. Don't create it directly, use the

--- a/pkg/golang/names.go
+++ b/pkg/golang/names.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // NamesCalculatorBuilder is an object used to configure and build the Go names calculators. Don't

--- a/pkg/golang/types.go
+++ b/pkg/golang/types.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"path"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // TypesCalculatorBuilder is an object used to configure and build the Go type calculators. Don't

--- a/pkg/language/ModelParser.g4
+++ b/pkg/language/ModelParser.g4
@@ -23,8 +23,8 @@ options {
 
 @header {
   import (
-    "gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-    "gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+    "github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+    "github.com/openshift-online/ocm-api-metamodel/pkg/names"
   )
 }
 

--- a/pkg/language/errors.go
+++ b/pkg/language/errors.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // ErrorListenerBuilder is used to build error listeners.

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/nomenclator"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // Reader is used to read a model from a set of files. Don't create objects of this type directly,

--- a/pkg/language/writer.go
+++ b/pkg/language/writer.go
@@ -22,8 +22,8 @@ package language
 import (
 	"fmt"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/concepts"
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
 )
 
 // Writer is used to write a model to a set of files. Don't create objects of this type directly,

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nomenclator
 
 import (
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
 var (

--- a/tests/builders_test.go
+++ b/tests/builders_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Builder", func() {

--- a/tests/readers_test.go
+++ b/tests/readers_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Reader", func() {

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gorilla/mux"
-	v1 "gitlab.cee.redhat.com/service/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 type MyTestRootServer struct{}

--- a/tests/types_test.go
+++ b/tests/types_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gitlab.cee.redhat.com/service/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Type", func() {


### PR DESCRIPTION
This patch moves the project to its new home in
`github.com/openshift-online`.