### PR TITLE
Add `check` command

### DIFF
--- a/cmd/ocm-metamodel-tool/check/cmd.go
+++ b/cmd/ocm-metamodel-tool/check/cmd.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+)
+
+// Cmd is the definition of the command:
+var Cmd = &cobra.Command{
+	Use:   "check",
+	Short: "Checks a model",
+	Long:  "Checka a model.",
+	Run:   run,
+}
+
+// Values of the command line arguments:
+var args struct {
+	paths []string
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.StringSliceVar(
+		&args.paths,
+		"model",
+		[]string{},
+		"File or directory containing the model. If it is a directory then all .model"+
+			"files inside it and its sub directories will be loaded. If used "+
+			"multiple times then all the specified files and directories will be "+
+			"loaded, in the same order that they appear in the command line.",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	// Create the reporter:
+	reporter := reporter.NewReporter()
+
+	// Check command line options:
+	ok := true
+	if len(args.paths) == 0 {
+		reporter.Errorf("Option '--model' is mandatory")
+		ok = false
+	}
+	if !ok {
+		os.Exit(1)
+	}
+
+	// Read the model:
+	_, err := language.NewReader().
+		Reporter(reporter).
+		Inputs(args.paths).
+		Read()
+	if err != nil {
+		reporter.Errorf("Check failed: %v", err)
+		os.Exit(1)
+	} else {
+		reporter.Infof("Check succeeded")
+	}
+
+	// Bye:
+	os.Exit(0)
+}

--- a/cmd/ocm-metamodel-tool/main.go
+++ b/cmd/ocm-metamodel-tool/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift-online/ocm-api-metamodel/cmd/ocm-metamodel-tool/check"
 	"github.com/openshift-online/ocm-api-metamodel/cmd/ocm-metamodel-tool/generate"
 	"github.com/openshift-online/ocm-api-metamodel/cmd/ocm-metamodel-tool/version"
 )
@@ -40,6 +41,7 @@ func init() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	// Register the subcommands:
+	root.AddCommand(check.Cmd)
 	root.AddCommand(generate.Cmd)
 	root.AddCommand(version.Cmd)
 }


### PR DESCRIPTION
This patch adds to the tool a new `check` command that loads the model
but doesn't generate any code. This is inteded to be used in the jobs
that check pull requests for the model project.