### PR TITLE
Don't install binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ model_url:=https://github.com/openshift-online/ocm-api-model.git
 cmds: generate
 	for cmd in $$(ls cmd); do \
 		go build -o "$${cmd}" "./cmd/$${cmd}" || exit 1; \
-		cp "$${cmd}" "$${HOME}/bin/."; \
 	done
 
 .PHONY: generate


### PR DESCRIPTION
This patch changes the _Makefile_ of the project so that the _cmds_
target doesn't copy the generated binaries to the `bin` directory of the
user, as that isn't possible in the Jenkins environment.