### PR TITLE
Release 0.0.3

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.3 Aug 27 2019
+
+- Don't install binaries.
+
 == 0.0.2 Aug 27 2019
 
 - Added new `check` command that loads and checks the model but doesn't

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.2"
+const Version = "0.0.3"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Don't install binaries.