### PR TITLE
Parse request query arguments

### DIFF
--- a/pkg/generators/readers.go
+++ b/pkg/generators/readers.go
@@ -199,6 +199,8 @@ func (g *ReadersGenerator) generateHelpers() error {
 	g.buffer.Import("encoding/json", "")
 	g.buffer.Import("fmt", "")
 	g.buffer.Import("io", "")
+	g.buffer.Import("net/url", "")
+	g.buffer.Import("strconv", "")
 	g.buffer.Emit(`
 		// NewEncoder creates a new JSON encoder from the given target. The target can be a
 		// a writer or a JSON encoder.
@@ -236,6 +238,128 @@ func (g *ReadersGenerator) generateHelpers() error {
 				)
 			}
 			return
+		}
+
+		// ParseInteger reads a string and parses it to integer,
+		// if an error ocurred it returns a non-nil error.
+		func ParseInteger(query url.Values, parameterName string) (*int, error) {
+			values := query[parameterName]
+			count := len(values)
+			if count == 0 {
+				return nil, nil
+			}
+		   	if count > 1 {
+				err := fmt.Errorf(
+					"expected at most one value for parameter '%s' but got %d",
+					parameterName, count,
+				)
+				return nil, err
+			}
+			value := values[0]
+			parsedInt64, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"value '%s' isn't valid for the '%s' parameter because it isn't an integer: %v",
+					value, parameterName, err,
+				)
+			}
+			parsedInt := int(parsedInt64)
+			return &parsedInt, nil
+		}
+
+		// ParseFloat reads a string and parses it to float,
+		// if an error ocurred it returns a non-nil error.
+		func ParseFloat(query url.Values, parameterName string) (*float64, error) {
+			values := query[parameterName]
+			count := len(values)
+			if count == 0 {
+				return nil, nil
+			}
+		   	if count > 1 {
+				err := fmt.Errorf(
+					"expected at most one value for parameter '%s' but got %d",
+					parameterName, count,
+				)
+				return nil, err
+			}
+			value := values[0]
+			parsedFloat, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"value '%s' isn't valid for the '%s' parameter because it isn't a float: %v",
+					value, parameterName, err,
+				)
+			}
+			return &parsedFloat, nil
+		}
+
+		// ParseString returns a pointer to the string and nil error.
+		func ParseString(query url.Values, parameterName string) (*string, error) {
+			values := query[parameterName]
+			count := len(values)
+			if count == 0 {
+				return nil, nil
+			}
+		   	if count > 1 {
+				err := fmt.Errorf(
+					"expected at most one value for parameter '%s' but got %d",
+					parameterName, count,
+				)
+				return nil, err
+			}
+			return &values[0], nil
+		}
+
+		// ParseBoolean reads a string and parses it to boolean,
+		// if an error ocurred it returns a non-nil error.
+		func ParseBoolean(query url.Values, parameterName string) (*bool, error) {
+			values := query[parameterName]
+			count := len(values)
+			if count == 0 {
+				return nil, nil
+			}
+		   	if count > 1 {
+				err := fmt.Errorf(
+					"expected at most one value for parameter '%s' but got %d",
+					parameterName, count,
+				)
+				return nil, err
+			}
+			value := values[0]
+			parsedBool, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"value '%s' isn't valid for the '%s' parameter because it isn't a boolean: %v",
+					value, parameterName, err,
+				)
+			}
+			return &parsedBool, nil
+		}
+
+		// ParseDate reads a string and parses it to a time.Time,
+		// if an error ocurred it returns a non-nil error.
+		func ParseDate(query url.Values, parameterName string) (*time.Time, error) {
+			values := query[parameterName]
+			count := len(values)
+			if count == 0 {
+				return nil, nil
+			}
+		   	if count > 1 {
+				err := fmt.Errorf(
+					"expected at most one value for parameter '%s' but got %d",
+					parameterName, count,
+				)
+				return nil, err
+			}
+			value := values[0]
+			parsedTime, err := time.Parse(time.RFC3339, value)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"value '%s' isn't valid for the '%s' parameter because it isn't a date: %v",
+					value, parameterName, err,
+				)
+			}
+			return &parsedTime, nil
 		}
 	`)
 

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -62,9 +62,9 @@ func (s *MyTestClustersServer) List(ctx context.Context, request *v1.ClustersLis
 	response.SetStatusCode(200)
 	// Set body of response
 	response.Items(items)
-	response.Page(1)
-	response.Size(1)
-	response.Total(1)
+	response.Page(request.Page())
+	response.Size(request.Size())
+	response.Total(items.Len())
 	return nil
 }
 
@@ -190,8 +190,65 @@ var _ = Describe("Server", func() {
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
+			"page":0,
+			"size":0,
+			"total":1,
+			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
+			}`
+
+		Expect(recorder.Body).To(MatchJSON(expected))
+		Expect(recorder.Result().StatusCode).To(Equal(200))
+	})
+
+	It("Can get a list of clusters by page", func() {
+		myTestRootServer := new(MyTestRootServer)
+		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+
+		request := httptest.NewRequest(http.MethodGet, "/clusters?page=2", nil)
+		recorder := httptest.NewRecorder()
+		rootAdapter.ServeHTTP(recorder, request)
+
+		expected := `{
+			"page":2,
+			"size":0,
+			"total":1,
+			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
+			}`
+
+		Expect(recorder.Body).To(MatchJSON(expected))
+		Expect(recorder.Result().StatusCode).To(Equal(200))
+	})
+
+	It("Can get a list of clusters by size", func() {
+		myTestRootServer := new(MyTestRootServer)
+		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+
+		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2", nil)
+		recorder := httptest.NewRecorder()
+		rootAdapter.ServeHTTP(recorder, request)
+
+		expected := `{
+			"page":0,
+			"size":2,
+			"total":1,
+			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
+			}`
+
+		Expect(recorder.Body).To(MatchJSON(expected))
+		Expect(recorder.Result().StatusCode).To(Equal(200))
+	})
+
+	It("Can get a list of clusters by size and page", func() {
+		myTestRootServer := new(MyTestRootServer)
+		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+
+		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2&page=1", nil)
+		recorder := httptest.NewRecorder()
+		rootAdapter.ServeHTTP(recorder, request)
+
+		expected := `{
 			"page":1,
-			"size":1,
+			"size":2,
 			"total":1,
 			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
 			}`


### PR DESCRIPTION
## What this patch does?

1. In the current implementation we had disregarded the request query parameters, this patch fixes this issue.
2. This patch also adds tests to address this issue.

cc: @jhernand 
