### PR TITLE
Install `goimports`

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -25,6 +25,7 @@ export PATH="${GOBIN}:${PATH}"
 
 # Install Go tools:
 go get github.com/onsi/ginkgo/ginkgo
+go get golang.org/x/tools/cmd/goimports
 
 # Run the tests:
 make tests


### PR DESCRIPTION
This patch changes the `pr_check.sh` script that runs in Jenkins so that
it installs the `goimports` tool that is needed to run the model tests.