### PR TITLE
Release 0.0.5

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.5 Sep 10 2019
+
+- Fix generation of field names for query parameters.
+- Remove `query` and `path` fields from request objects.
+- Remove unused imports.
+
 == 0.0.4 Sep 03 2019
 
 - Generated servers parse request query arguments.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.4"
+const Version = "0.0.5"


### PR DESCRIPTION
The more relevant changes in this version are the following:

- Fix generation of field names for query parameters.
- Remove `query` and `path` fields from request objects.
- Remove unused imports.