### PR TITLE
Release 0.0.6

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.6 Sep 12 2019
+
+- Explicitly enable Go modules so that the build works correctly when the
+  project is located inside the Go path.
+
 == 0.0.5 Sep 10 2019
 
 - Fix generation of field names for query parameters.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.5"
+const Version = "0.0.6"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Explicitly enable Go modules so that the build works correctly when the
  project is located inside the Go path.