### PR TITLE
Add `Copy` method to builders

### DIFF
--- a/tests/builders_test.go
+++ b/tests/builders_test.go
@@ -111,4 +111,36 @@ var _ = Describe("Builder", func() {
 		Expect(slice[1]).ToNot(BeNil())
 		Expect(slice[1].ID()).To(Equal("b-group"))
 	})
+
+	Describe("Copy", func() {
+		It("Copies simple attribute", func() {
+			original, err := v1.NewCluster().
+				ID("123").
+				Name("my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := v1.NewCluster().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(replica.ID()).To(Equal("123"))
+			Expect(replica.Name()).To(Equal("my"))
+		})
+
+		It("Discards existing values", func() {
+			original, err := v1.NewCluster().
+				ID("123").
+				Name("my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := v1.NewCluster().
+				ID("456").
+				Name("your").
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(replica.ID()).To(Equal("123"))
+			Expect(replica.Name()).To(Equal("my"))
+		})
+	})
 })


### PR DESCRIPTION
This patch adds to builders a new `Copy` method that can be used to copy
the contents of an existing object. For example, to create a copy of a
cluster and then change the name:

```go
// Get the original cluster:
original := ...

// Create the modified cluster copying the original and then changing
// the name:
modified, err := cmv1.NewCluster().
	Copy(original).
	Name("newname").
	Build()
if err != nil {
	...
}
```