### PR TITLE
Keep concepts sorted by name

### DIFF
--- a/pkg/concepts/attribute.go
+++ b/pkg/concepts/attribute.go
@@ -83,3 +83,18 @@ func (a *Attribute) Type() *Type {
 func (a *Attribute) SetType(value *Type) {
 	a.typ = value
 }
+
+// AttributeSlice is used to simplify sorting of slices of attributes by name.
+type AttributeSlice []*Attribute
+
+func (s AttributeSlice) Len() int {
+	return len(s)
+}
+
+func (s AttributeSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s AttributeSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/concepts/error.go
+++ b/pkg/concepts/error.go
@@ -72,3 +72,18 @@ func (e *Error) Code() int {
 func (e *Error) SetCode(value int) {
 	e.code = value
 }
+
+// ErrorSlice is used to simplify sorting of slices of errors by name.
+type ErrorSlice []*Error
+
+func (s ErrorSlice) Len() int {
+	return len(s)
+}
+
+func (s ErrorSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s ErrorSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/concepts/locator.go
+++ b/pkg/concepts/locator.go
@@ -86,3 +86,18 @@ func (l *Locator) Target() *Resource {
 func (l *Locator) SetTarget(value *Resource) {
 	l.target = value
 }
+
+// LocatorSlice is used to simplify sorting of slices of locators by name.
+type LocatorSlice []*Locator
+
+func (s LocatorSlice) Len() int {
+	return len(s)
+}
+
+func (s LocatorSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s LocatorSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
@@ -25,7 +27,7 @@ type Method struct {
 	owner      *Resource
 	doc        string
 	name       *names.Name
-	parameters []*Parameter
+	parameters ParameterSlice
 }
 
 // NewMethod creates a new method.
@@ -64,7 +66,7 @@ func (m *Method) SetName(value *names.Name) {
 }
 
 // Parameters returns the parameters of the method.
-func (m *Method) Parameters() []*Parameter {
+func (m *Method) Parameters() ParameterSlice {
 	return m.parameters
 }
 
@@ -72,6 +74,7 @@ func (m *Method) Parameters() []*Parameter {
 func (m *Method) AddParameter(parameter *Parameter) {
 	if parameter != nil {
 		m.parameters = append(m.parameters, parameter)
+		sort.Sort(m.parameters)
 		parameter.SetOwner(m)
 	}
 }
@@ -88,4 +91,19 @@ func (m *Method) GetParameter(name *names.Name) *Parameter {
 		}
 	}
 	return nil
+}
+
+// MethodSlice is used to simplify sorting of slices of methods by name.
+type MethodSlice []*Method
+
+func (s MethodSlice) Len() int {
+	return len(s)
+}
+
+func (s MethodSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s MethodSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }

--- a/pkg/concepts/model.go
+++ b/pkg/concepts/model.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
@@ -34,14 +36,15 @@ func NewModel() *Model {
 }
 
 // Services returns the list of services that are part of this model.
-func (m *Model) Services() []*Service {
+func (m *Model) Services() ServiceSlice {
 	count := len(m.services)
-	services := make([]*Service, count)
+	services := make(ServiceSlice, count)
 	index := 0
 	for _, service := range m.services {
 		services[index] = service
 		index++
 	}
+	sort.Sort(services)
 	return services
 }
 

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -94,3 +94,18 @@ func (p *Parameter) Out() bool {
 func (p *Parameter) SetOut(value bool) {
 	p.out = value
 }
+
+// ParameterSlice is used to simplify sorting of slices of attributes by name.
+type ParameterSlice []*Parameter
+
+func (s ParameterSlice) Len() int {
+	return len(s)
+}
+
+func (s ParameterSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s ParameterSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
@@ -25,8 +27,8 @@ type Resource struct {
 	owner    *Version
 	doc      string
 	name     *names.Name
-	methods  []*Method
-	locators []*Locator
+	methods  MethodSlice
+	locators LocatorSlice
 }
 
 // NewResource creates a new resource.
@@ -65,7 +67,7 @@ func (r *Resource) SetName(value *names.Name) {
 }
 
 // Methods returns the methods of the resource.
-func (r *Resource) Methods() []*Method {
+func (r *Resource) Methods() MethodSlice {
 	return r.methods
 }
 
@@ -73,12 +75,13 @@ func (r *Resource) Methods() []*Method {
 func (r *Resource) AddMethod(method *Method) {
 	if method != nil {
 		r.methods = append(r.methods, method)
+		sort.Sort(r.methods)
 		method.SetOwner(r)
 	}
 }
 
 // Locators returns the locators of the resource.
-func (r *Resource) Locators() []*Locator {
+func (r *Resource) Locators() LocatorSlice {
 	return r.locators
 }
 
@@ -86,6 +89,22 @@ func (r *Resource) Locators() []*Locator {
 func (r *Resource) AddLocator(locator *Locator) {
 	if locator != nil {
 		r.locators = append(r.locators, locator)
+		sort.Sort(r.locators)
 		locator.SetOwner(r)
 	}
+}
+
+// ResourceSlice is used to simplify sorting of slices of resources by name.
+type ResourceSlice []*Resource
+
+func (s ResourceSlice) Len() int {
+	return len(s)
+}
+
+func (s ResourceSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s ResourceSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }

--- a/pkg/concepts/service.go
+++ b/pkg/concepts/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
@@ -61,14 +63,15 @@ func (s *Service) SetName(value *names.Name) {
 }
 
 // Versions returns the list of versions of the service.
-func (s *Service) Versions() []*Version {
+func (s *Service) Versions() VersionSlice {
 	count := len(s.versions)
-	versions := make([]*Version, count)
+	versions := make(VersionSlice, count)
 	index := 0
 	for _, version := range s.versions {
 		versions[index] = version
 		index++
 	}
+	sort.Sort(versions)
 	return versions
 }
 
@@ -95,4 +98,19 @@ func (s *Service) AddVersions(versions []*Version) {
 			s.AddVersion(version)
 		}
 	}
+}
+
+// ServiceSlice is used to simplify sorting of slices of services by name.
+type ServiceSlice []*Service
+
+func (s ServiceSlice) Len() int {
+	return len(s)
+}
+
+func (s ServiceSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s ServiceSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
@@ -67,8 +69,8 @@ type Type struct {
 	doc        string
 	kind       TypeKind
 	name       *names.Name
-	attributes []*Attribute
-	values     []*EnumValue
+	attributes AttributeSlice
+	values     EnumValueSlice
 	element    *Type
 	index      *Type
 }
@@ -146,7 +148,7 @@ func (t *Type) SetName(value *names.Name) {
 
 // Attributes returns the list of attributes of an struct type. If called for any other kind of type
 // it will return nil.
-func (t *Type) Attributes() []*Attribute {
+func (t *Type) Attributes() AttributeSlice {
 	return t.attributes
 }
 
@@ -154,13 +156,14 @@ func (t *Type) Attributes() []*Attribute {
 func (t *Type) AddAttribute(attribute *Attribute) {
 	if attribute != nil {
 		t.attributes = append(t.attributes, attribute)
+		sort.Sort(t.attributes)
 		attribute.SetOwner(t)
 	}
 }
 
 // Values returns the list of values of an enumerated type. If called for any other kind of type it
 // will return nil.
-func (t *Type) Values() []*EnumValue {
+func (t *Type) Values() EnumValueSlice {
 	return t.values
 }
 
@@ -168,6 +171,7 @@ func (t *Type) Values() []*EnumValue {
 func (t *Type) AddValue(value *EnumValue) {
 	if value != nil {
 		t.values = append(t.values, value)
+		sort.Sort(t.values)
 		value.SetType(t)
 	}
 }
@@ -183,7 +187,7 @@ func (t *Type) SetElement(value *Type) {
 	t.element = value
 }
 
-// Index returns the index type for a list tpype. If called for any other kind of type it will
+// Index returns the index type for a list type. If called for any other kind of type it will
 // return nil.
 func (t *Type) Index() *Type {
 	return t.index
@@ -192,6 +196,21 @@ func (t *Type) Index() *Type {
 // SetIndex sets the index type for a map type.
 func (t *Type) SetIndex(value *Type) {
 	t.index = value
+}
+
+// TypeSlice is used to simplify sorting of slices of types by name.
+type TypeSlice []*Type
+
+func (s TypeSlice) Len() int {
+	return len(s)
+}
+
+func (s TypeSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s TypeSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }
 
 // EnumValue represents each of the values of an enum type.
@@ -234,4 +253,19 @@ func (v *EnumValue) Name() *names.Name {
 // SetName sets the name of this enum value.
 func (v *EnumValue) SetName(value *names.Name) {
 	v.name = value
+}
+
+// EnumValueSlice is used to simplify sorting of slices of enum values by name.
+type EnumValueSlice []*EnumValue
+
+func (s EnumValueSlice) Len() int {
+	return len(s)
+}
+
+func (s EnumValueSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s EnumValueSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -17,6 +17,8 @@ limitations under the License.
 package concepts
 
 import (
+	"sort"
+
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
 )
@@ -79,14 +81,15 @@ func (v *Version) SetName(value *names.Name) {
 }
 
 // Types returns the list of types that are part of this version.
-func (v *Version) Types() []*Type {
+func (v *Version) Types() TypeSlice {
 	count := len(v.types)
-	types := make([]*Type, count)
+	types := make(TypeSlice, count)
 	index := 0
 	for _, typ := range v.types {
 		types[index] = typ
 		index++
 	}
+	sort.Sort(types)
 	return types
 }
 
@@ -144,14 +147,15 @@ func (v *Version) Date() *Type {
 }
 
 // Resources returns the list of resources that are part of this version.
-func (v *Version) Resources() []*Resource {
+func (v *Version) Resources() ResourceSlice {
 	count := len(v.resources)
-	resources := make([]*Resource, count)
+	resources := make(ResourceSlice, count)
 	index := 0
 	for _, resource := range v.resources {
 		resources[index] = resource
 		index++
 	}
+	sort.Sort(resources)
 	return resources
 }
 
@@ -184,14 +188,15 @@ func (v *Version) Root() *Resource {
 }
 
 // Errors returns the list of errors that are part of this version.
-func (v *Version) Errors() []*Error {
+func (v *Version) Errors() ErrorSlice {
 	count := len(v.errors)
-	errors := make([]*Error, count)
+	errors := make(ErrorSlice, count)
 	index := 0
 	for _, err := range v.errors {
 		errors[index] = err
 		index++
 	}
+	sort.Sort(errors)
 	return errors
 }
 
@@ -231,4 +236,19 @@ func (v *Version) addScalarType(name *names.Name) {
 	listType.SetName(names.Cat(name, nomenclator.List))
 	listType.SetElement(scalarType)
 	v.AddType(listType)
+}
+
+// VersionSlice is used to simplify sorting of slices of versions by name.
+type VersionSlice []*Version
+
+func (s VersionSlice) Len() int {
+	return len(s)
+}
+
+func (s VersionSlice) Less(i, j int) bool {
+	return names.Compare(s[i].name, s[j].name) == -1
+}
+
+func (s VersionSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
This patch changes the metamodel so that all list of concepts are always
kept sorted by name. This is intended to ensure that the generated code
doesn't change when the order of the concepts in the input chages, or
when the algorithms used internally to populate the metamodel change.