### PR TITLE
Don't generate empty set of constants for errors

### DIFF
--- a/pkg/generators/clients.go
+++ b/pkg/generators/clients.go
@@ -689,12 +689,14 @@ func (g *ClientsGenerator) generateVersionErrors(version *concepts.Version) erro
 
 func (g *ClientsGenerator) generateVersionErrorsSource(version *concepts.Version) error {
 	g.buffer.Emit(`
-		const (
-			{{ range .Version.Errors }}
-				{{ lineComment .Doc }}
-				{{ errorName . }} = {{ .Code }}
-			{{ end }}
-		)
+		{{ if .Version.Errors }}
+			const (
+				{{ range .Version.Errors }}
+					{{ lineComment .Doc }}
+					{{ errorName . }} = {{ .Code }}
+				{{ end }}
+			)
+		{{ end }}
 		`,
 		"Version", version,
 	)


### PR DESCRIPTION
Currently the code generator generates an empty `const (...)` when there
are no errors defined in the API. This will be removed by `gofmt` but
it is frequent to forget to run it when the SDK is updated, and as a
result those pull requests are rejected. To avoid that this patch
changes the code so that it doesn't generate that empty `const`.