### PR TITLE
Release 0.0.7

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.7 Sep 13 2019
+
+- Keep concepts sorted by name.
+- Don't generate empty `const` block for errors.
+- Add `Copy` method to builders.
+
 == 0.0.6 Sep 12 2019
 
 - Explicitly enable Go modules so that the build works correctly when the

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.6"
+const Version = "0.0.7"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Keep concepts sorted by name.
- Don't generate empty `const` block for errors.
- Add `Copy` method to builders.