### PR TITLE
Use `cmv1` instead of `v1` as package selector

### DIFF
--- a/tests/builders_test.go
+++ b/tests/builders_test.go
@@ -22,12 +22,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Builder", func() {
 	It("Can set empty string list attribute", func() {
-		object, err := v1.NewGithubIdentityProvider().
+		object, err := cmv1.NewGithubIdentityProvider().
 			Teams().
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -38,7 +38,7 @@ var _ = Describe("Builder", func() {
 	})
 
 	It("Can set string list attribute with one value", func() {
-		object, err := v1.NewGithubIdentityProvider().
+		object, err := cmv1.NewGithubIdentityProvider().
 			Teams("a-team").
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -50,7 +50,7 @@ var _ = Describe("Builder", func() {
 	})
 
 	It("Can set string list attribute with two values", func() {
-		object, err := v1.NewGithubIdentityProvider().
+		object, err := cmv1.NewGithubIdentityProvider().
 			Teams("a-team", "b-team").
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Builder", func() {
 	})
 
 	It("Can set empty struct list attribute", func() {
-		object, err := v1.NewCluster().
+		object, err := cmv1.NewCluster().
 			Groups().
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -74,9 +74,9 @@ var _ = Describe("Builder", func() {
 	})
 
 	It("Can set struct list attribute with one value", func() {
-		object, err := v1.NewCluster().
+		object, err := cmv1.NewCluster().
 			Groups(
-				v1.NewGroup().ID("a-group"),
+				cmv1.NewGroup().ID("a-group"),
 			).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -92,10 +92,10 @@ var _ = Describe("Builder", func() {
 	})
 
 	It("Can set struct list attribute with two values", func() {
-		object, err := v1.NewCluster().
+		object, err := cmv1.NewCluster().
 			Groups(
-				v1.NewGroup().ID("a-group"),
-				v1.NewGroup().ID("b-group"),
+				cmv1.NewGroup().ID("a-group"),
+				cmv1.NewGroup().ID("b-group"),
 			).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -114,12 +114,12 @@ var _ = Describe("Builder", func() {
 
 	Describe("Copy", func() {
 		It("Copies simple attribute", func() {
-			original, err := v1.NewCluster().
+			original, err := cmv1.NewCluster().
 				ID("123").
 				Name("my").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			replica, err := v1.NewCluster().
+			replica, err := cmv1.NewCluster().
 				Copy(original).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -128,12 +128,12 @@ var _ = Describe("Builder", func() {
 		})
 
 		It("Discards existing values", func() {
-			original, err := v1.NewCluster().
+			original, err := cmv1.NewCluster().
 				ID("123").
 				Name("my").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			replica, err := v1.NewCluster().
+			replica, err := cmv1.NewCluster().
 				ID("456").
 				Name("your").
 				Copy(original).

--- a/tests/readers_test.go
+++ b/tests/readers_test.go
@@ -22,15 +22,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Reader", func() {
 	It("Can read empty object", func() {
-		object, err := v1.UnmarshalCluster(`{} `)
+		object, err := cmv1.UnmarshalCluster(`{}`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object).ToNot(BeNil())
-		Expect(object.Kind()).To(Equal(v1.ClusterKind))
+		Expect(object.Kind()).To(Equal(cmv1.ClusterKind))
 		Expect(object.Link()).To(BeFalse())
 		Expect(object.ID()).To(BeEmpty())
 		Expect(object.HREF()).To(BeEmpty())
@@ -38,17 +38,17 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read empty link", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"kind": "ClusterLink"
 		}`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object).ToNot(BeNil())
-		Expect(object.Kind()).To(Equal(v1.ClusterLinkKind))
+		Expect(object.Kind()).To(Equal(cmv1.ClusterLinkKind))
 		Expect(object.Link()).To(BeTrue())
 	})
 
 	It("Can read basic object", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"kind": "Cluster",
 			"id": "123",
 			"href": "/api/clusters_mgmt/v1/clusters/123",
@@ -56,7 +56,7 @@ var _ = Describe("Reader", func() {
 		}`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object).ToNot(BeNil())
-		Expect(object.Kind()).To(Equal(v1.ClusterKind))
+		Expect(object.Kind()).To(Equal(cmv1.ClusterKind))
 		Expect(object.Link()).To(BeFalse())
 		Expect(object.ID()).To(Equal("123"))
 		Expect(object.HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123"))
@@ -64,7 +64,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read true", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"managed": true
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read false", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"managed": false
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -80,7 +80,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read integer zero", func() {
-		object, err := v1.UnmarshalClusterNodes(`{
+		object, err := cmv1.UnmarshalClusterNodes(`{
 			"compute": 0
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -88,7 +88,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read integer one", func() {
-		object, err := v1.UnmarshalClusterNodes(`{
+		object, err := cmv1.UnmarshalClusterNodes(`{
 			"compute": 1
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read integer minus one", func() {
-		object, err := v1.UnmarshalClusterNodes(`{
+		object, err := cmv1.UnmarshalClusterNodes(`{
 			"compute": -1
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -104,7 +104,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read false", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"managed": false
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,7 +112,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read object with one unknown attribute", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"myname": "myvalue"
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -120,7 +120,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read object with two unknown attributes", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"myname": "myvalue",
 			"yourname": "yourvalue"
 		}`)
@@ -129,14 +129,14 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read an empty list of objects", func() {
-		object, err := v1.UnmarshalClusterList(`[]`)
+		object, err := cmv1.UnmarshalClusterList(`[]`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object).ToNot(BeNil())
 		Expect(object.Len()).To(BeZero())
 	})
 
 	It("Can read list with one element", func() {
-		list, err := v1.UnmarshalClusterList(`[
+		list, err := cmv1.UnmarshalClusterList(`[
 			{
 				"name": "mycluster"
 			}
@@ -152,7 +152,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read list with two elements", func() {
-		list, err := v1.UnmarshalClusterList(`[
+		list, err := cmv1.UnmarshalClusterList(`[
 			{
 				"name": "mycluster"
 			},
@@ -173,7 +173,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read empty string list attribute", func() {
-		object, err := v1.UnmarshalGithubIdentityProvider(`{
+		object, err := cmv1.UnmarshalGithubIdentityProvider(`{
 			"teams": []
 		}`)
 		Expect(err).ToNot(HaveOccurred())
@@ -184,7 +184,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read string list attribute with one element", func() {
-		object, err := v1.UnmarshalGithubIdentityProvider(`{
+		object, err := cmv1.UnmarshalGithubIdentityProvider(`{
 			"teams": [
 				"a-team"
 			]
@@ -198,7 +198,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read string list attribute with two elements", func() {
-		object, err := v1.UnmarshalGithubIdentityProvider(`{
+		object, err := cmv1.UnmarshalGithubIdentityProvider(`{
 			"teams": [
 				"a-team",
 				"b-team"
@@ -214,7 +214,7 @@ var _ = Describe("Reader", func() {
 	})
 
 	It("Can read attribute that is link to a list of instances of a class", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"groups": {
 				"kind": "GroupListLink",
 				"href": "/api/clusters_mgmt/v1/clusters/123/groups"
@@ -224,14 +224,14 @@ var _ = Describe("Reader", func() {
 		Expect(object).ToNot(BeNil())
 		list := object.Groups()
 		Expect(list).ToNot(BeNil())
-		Expect(list.Kind()).To(Equal(v1.GroupListLinkKind))
+		Expect(list.Kind()).To(Equal(cmv1.GroupListLinkKind))
 		Expect(list.Link()).To(BeTrue())
 		Expect(list.HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups"))
 		Expect(list.Len()).To(BeZero())
 	})
 
 	It("Can read attribute that is a list of zero instances of a class", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"groups": {
 				"kind": "GroupList",
 				"href": "/api/clusters_mgmt/v1/clusters/123/groups",
@@ -242,14 +242,14 @@ var _ = Describe("Reader", func() {
 		Expect(object).ToNot(BeNil())
 		list := object.Groups()
 		Expect(list).ToNot(BeNil())
-		Expect(list.Kind()).To(Equal(v1.GroupListKind))
+		Expect(list.Kind()).To(Equal(cmv1.GroupListKind))
 		Expect(list.Link()).To(BeFalse())
 		Expect(list.HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups"))
 		Expect(list.Len()).To(BeZero())
 	})
 
 	It("Can read attribute that is a list of one instance of a class", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"groups": {
 				"kind": "GroupList",
 				"href": "/api/clusters_mgmt/v1/clusters/123/groups",
@@ -266,20 +266,20 @@ var _ = Describe("Reader", func() {
 		Expect(object).ToNot(BeNil())
 		list := object.Groups()
 		Expect(list).ToNot(BeNil())
-		Expect(list.Kind()).To(Equal(v1.GroupListKind))
+		Expect(list.Kind()).To(Equal(cmv1.GroupListKind))
 		Expect(list.Link()).To(BeFalse())
 		Expect(list.HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups"))
 		Expect(list.Len()).To(Equal(1))
 		slice := list.Slice()
 		Expect(slice).ToNot(BeNil())
 		Expect(slice).To(HaveLen(1))
-		Expect(slice[0].Kind()).To(Equal(v1.GroupKind))
+		Expect(slice[0].Kind()).To(Equal(cmv1.GroupKind))
 		Expect(slice[0].HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups/456"))
 		Expect(slice[0].ID()).To(Equal("456"))
 	})
 
 	It("Can read attribute that is a list of two instances of a class", func() {
-		object, err := v1.UnmarshalCluster(`{
+		object, err := cmv1.UnmarshalCluster(`{
 			"groups": {
 				"kind": "GroupList",
 				"href": "/api/clusters_mgmt/v1/clusters/123/groups",
@@ -301,17 +301,17 @@ var _ = Describe("Reader", func() {
 		Expect(object).ToNot(BeNil())
 		list := object.Groups()
 		Expect(list).ToNot(BeNil())
-		Expect(list.Kind()).To(Equal(v1.GroupListKind))
+		Expect(list.Kind()).To(Equal(cmv1.GroupListKind))
 		Expect(list.Link()).To(BeFalse())
 		Expect(list.HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups"))
 		Expect(list.Len()).To(Equal(2))
 		slice := list.Slice()
 		Expect(slice).ToNot(BeNil())
 		Expect(slice).To(HaveLen(2))
-		Expect(slice[0].Kind()).To(Equal(v1.GroupKind))
+		Expect(slice[0].Kind()).To(Equal(cmv1.GroupKind))
 		Expect(slice[0].HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups/456"))
 		Expect(slice[0].ID()).To(Equal("456"))
-		Expect(slice[1].Kind()).To(Equal(v1.GroupKind))
+		Expect(slice[1].Kind()).To(Equal(cmv1.GroupKind))
 		Expect(slice[1].HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups/789"))
 		Expect(slice[1].ID()).To(Equal("789"))
 	})

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -27,21 +27,21 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gorilla/mux"
-	v1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 type MyTestRootServer struct{}
 
-func (s *MyTestRootServer) Clusters() v1.ClustersServer {
+func (s *MyTestRootServer) Clusters() cmv1.ClustersServer {
 	return &MyTestClustersServer{}
 }
 
 type MyTestClustersServer struct{}
 
-func (s *MyTestClustersServer) List(ctx context.Context, request *v1.ClustersListServerRequest,
-	response *v1.ClustersListServerResponse) error {
-	items, err := v1.NewClusterList().
-		Items(v1.NewCluster().Name("test-list-clusters")).
+func (s *MyTestClustersServer) List(ctx context.Context, request *cmv1.ClustersListServerRequest,
+	response *cmv1.ClustersListServerResponse) error {
+	items, err := cmv1.NewClusterList().
+		Items(cmv1.NewCluster().Name("test-list-clusters")).
 		Build()
 	if err != nil {
 		return err
@@ -56,21 +56,23 @@ func (s *MyTestClustersServer) List(ctx context.Context, request *v1.ClustersLis
 	return nil
 }
 
-func (s *MyTestClustersServer) Add(ctx context.Context, request *v1.ClustersAddServerRequest, response *v1.ClustersAddServerResponse) error {
+func (s *MyTestClustersServer) Add(ctx context.Context, request *cmv1.ClustersAddServerRequest,
+	response *cmv1.ClustersAddServerResponse) error {
 	// Set a status code 200. Return empty response.
 	response.SetStatusCode(200)
 	return nil
 }
 
-func (s *MyTestClustersServer) Cluster(id string) v1.ClusterServer {
+func (s *MyTestClustersServer) Cluster(id string) cmv1.ClusterServer {
 	return &MyTestClusterServer{}
 }
 
 type MyTestClusterServer struct{}
 
-func (s *MyTestClusterServer) Get(ctx context.Context, request *v1.ClusterGetServerRequest, response *v1.ClusterGetServerResponse) error {
+func (s *MyTestClusterServer) Get(ctx context.Context, request *cmv1.ClusterGetServerRequest,
+	response *cmv1.ClusterGetServerResponse) error {
 	response.SetStatusCode(200)
-	cluster, err := v1.NewCluster().Name("test-get-cluster-by-id").Build()
+	cluster, err := cmv1.NewCluster().Name("test-get-cluster-by-id").Build()
 	if err != nil {
 		return err
 	}
@@ -78,29 +80,33 @@ func (s *MyTestClusterServer) Get(ctx context.Context, request *v1.ClusterGetSer
 	return nil
 }
 
-func (s *MyTestClusterServer) Update(ctx context.Context, request *v1.ClusterUpdateServerRequest, response *v1.ClusterUpdateServerResponse) error {
+func (s *MyTestClusterServer) Update(ctx context.Context, request *cmv1.ClusterUpdateServerRequest,
+	response *cmv1.ClusterUpdateServerResponse) error {
 	response.SetStatusCode(200)
 	return nil
 }
 
-func (s *MyTestClusterServer) Delete(ctx context.Context, request *v1.ClusterDeleteServerRequest, response *v1.ClusterDeleteServerResponse) error {
+func (s *MyTestClusterServer) Delete(ctx context.Context, request *cmv1.ClusterDeleteServerRequest,
+	response *cmv1.ClusterDeleteServerResponse) error {
 	response.SetStatusCode(200)
 	return nil
 }
 
-func (s *MyTestClusterServer) Groups() v1.GroupsServer {
+func (s *MyTestClusterServer) Groups() cmv1.GroupsServer {
 	return nil
 }
 
-func (s *MyTestClusterServer) IdentityProviders() v1.IdentityProvidersServer {
+func (s *MyTestClusterServer) IdentityProviders() cmv1.IdentityProvidersServer {
 	return &MyTestIdentityProvidersServer{}
 }
 
 type MyTestIdentityProvidersServer struct{}
 
-func (s *MyTestIdentityProvidersServer) List(ctx context.Context, request *v1.IdentityProvidersListServerRequest, response *v1.IdentityProvidersListServerResponse) error {
-	items, err := v1.NewIdentityProviderList().
-		Items(v1.NewIdentityProvider().Name("test-list-identity-providers")).
+func (s *MyTestIdentityProvidersServer) List(ctx context.Context,
+	request *cmv1.IdentityProvidersListServerRequest,
+	response *cmv1.IdentityProvidersListServerResponse) error {
+	items, err := cmv1.NewIdentityProviderList().
+		Items(cmv1.NewIdentityProvider().Name("test-list-identity-providers")).
 		Build()
 	if err != nil {
 		return err
@@ -115,18 +121,20 @@ func (s *MyTestIdentityProvidersServer) List(ctx context.Context, request *v1.Id
 	return nil
 }
 
-func (s *MyTestIdentityProvidersServer) Add(ctx context.Context, request *v1.IdentityProvidersAddServerRequest, response *v1.IdentityProvidersAddServerResponse) error {
+func (s *MyTestIdentityProvidersServer) Add(ctx context.Context,
+	request *cmv1.IdentityProvidersAddServerRequest,
+	response *cmv1.IdentityProvidersAddServerResponse) error {
 	return nil
 }
 
-func (s *MyTestIdentityProvidersServer) IdentityProvider(id string) v1.IdentityProviderServer {
+func (s *MyTestIdentityProvidersServer) IdentityProvider(id string) cmv1.IdentityProviderServer {
 	return nil
 }
 
 var _ = Describe("Server", func() {
 	It("Can receive a request and return response", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters", nil)
 		recorder := httptest.NewRecorder()
@@ -137,7 +145,7 @@ var _ = Describe("Server", func() {
 
 	It("Returns a 404 for a path with a trailing slash", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/", nil)
 		recorder := httptest.NewRecorder()
@@ -148,7 +156,7 @@ var _ = Describe("Server", func() {
 
 	It("Returns a 404 for an unkown resource", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/foo", nil)
 		recorder := httptest.NewRecorder()
@@ -159,18 +167,23 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters", nil)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
-			"page":0,
-			"size":0,
-			"total":1,
-			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
-			}`
+			"page": 0,
+			"size": 0,
+			"total": 1,
+			"items": [
+				{
+					"kind": "Cluster",
+					"name": "test-list-clusters"
+				}
+			]
+		}`
 
 		Expect(recorder.Body).To(MatchJSON(expected))
 		Expect(recorder.Result().StatusCode).To(Equal(200))
@@ -178,7 +191,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by page", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?page=2", nil)
 		recorder := httptest.NewRecorder()
@@ -197,18 +210,23 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by size", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2", nil)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
-			"page":0,
-			"size":2,
-			"total":1,
-			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
-			}`
+			"page": 0,
+			"size": 2,
+			"total": 1,
+			"items": [
+				{
+					"kind": "Cluster",
+					"name": "test-list-clusters"
+				}
+			]
+		}`
 
 		Expect(recorder.Body).To(MatchJSON(expected))
 		Expect(recorder.Result().StatusCode).To(Equal(200))
@@ -216,18 +234,23 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by size and page", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2&page=1", nil)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
-			"page":1,
-			"size":2,
-			"total":1,
-			"items":[{"kind":"Cluster","name":"test-list-clusters"}]
-			}`
+			"page": 1,
+			"size": 2,
+			"total": 1,
+			"items": [
+				{
+					"kind": "Cluster",
+					"name": "test-list-clusters"
+				}
+			]
+		}`
 
 		Expect(recorder.Body).To(MatchJSON(expected))
 		Expect(recorder.Result().StatusCode).To(Equal(200))
@@ -235,16 +258,16 @@ var _ = Describe("Server", func() {
 
 	It("Can get a cluster by id", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/123", nil)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
-			"kind":"Cluster",
-			"name":"test-get-cluster-by-id"
-			}`
+			"kind": "Cluster",
+			"name": "test-get-cluster-by-id"
+		}`
 
 		Expect(recorder.Body).To(MatchJSON(expected))
 		Expect(recorder.Result().StatusCode).To(Equal(200))
@@ -252,18 +275,27 @@ var _ = Describe("Server", func() {
 
 	It("Can get a cluster sub resource by id", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
-		request := httptest.NewRequest(http.MethodGet, "/clusters/123/identity_providers", nil)
+		request := httptest.NewRequest(
+			http.MethodGet,
+			"/clusters/123/identity_providers",
+			nil,
+		)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
 		expected := `{
-			"page":1,
-			"size":1,
-			"total":1,
-			"items":[{"kind":"IdentityProvider","name":"test-list-identity-providers"}]
-			}`
+			"page": 1,
+			"size": 1,
+			"total": 1,
+			"items": [
+				{
+					"kind": "IdentityProvider",
+					"name": "test-list-identity-providers"
+				}
+			]
+		}`
 
 		Expect(recorder.Body).To(MatchJSON(expected))
 		Expect(recorder.Result().StatusCode).To(Equal(200))
@@ -271,7 +303,7 @@ var _ = Describe("Server", func() {
 
 	It("Returns a 404 for an unkown sub resource", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := v1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootServerAdapter(myTestRootServer, mux.NewRouter())
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/123/foo", nil)
 		recorder := httptest.NewRecorder()

--- a/tests/types_test.go
+++ b/tests/types_test.go
@@ -22,32 +22,32 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Type", func() {
 	Describe("Kind", func() {
 		It("Returns nil nil", func() {
-			var object *v1.Cluster
-			Expect(object.Kind()).To(Equal(v1.ClusterNilKind))
+			var object *cmv1.Cluster
+			Expect(object.Kind()).To(Equal(cmv1.ClusterNilKind))
 		})
 	})
 
 	Describe("Link", func() {
 		It("Returns false on nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			Expect(object.Link()).To(BeFalse())
 		})
 	})
 
 	Describe("ID", func() {
 		It("Can get value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			Expect(object.ID()).To(BeEmpty())
 		})
 
 		It("Can check value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			value, ok := object.GetID()
 			Expect(ok).To(BeFalse())
 			Expect(value).To(BeEmpty())
@@ -56,12 +56,12 @@ var _ = Describe("Type", func() {
 
 	Describe("HREF", func() {
 		It("Can get value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			Expect(object.HREF()).To(BeEmpty())
 		})
 
 		It("Can check value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			value, ok := object.GetHREF()
 			Expect(ok).To(BeFalse())
 			Expect(value).To(BeEmpty())
@@ -70,12 +70,12 @@ var _ = Describe("Type", func() {
 
 	Describe("String attribute", func() {
 		It("Can get value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			Expect(object.Name()).To(BeEmpty())
 		})
 
 		It("Can check value of nil", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			value, ok := object.GetName()
 			Expect(ok).To(BeFalse())
 			Expect(value).To(BeEmpty())
@@ -84,20 +84,20 @@ var _ = Describe("Type", func() {
 
 	Describe("Get", func() {
 		It("Returns nil for nil list ", func() {
-			var list *v1.ClusterList
+			var list *cmv1.ClusterList
 			Expect(list.Get(0)).To(BeNil())
 		})
 
 		It("Returns nil for empty list ", func() {
-			list, err := v1.NewClusterList().Build()
+			list, err := cmv1.NewClusterList().Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Get(0)).To(BeNil())
 		})
 
 		It("Returns nil for negative index", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("123"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -105,9 +105,9 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns nil for positive index out of range", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("123"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -115,10 +115,10 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns first item for zero", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("0"),
-					v1.NewCluster().ID("1"),
+					cmv1.NewCluster().ID("0"),
+					cmv1.NewCluster().ID("1"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -128,10 +128,10 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns second item for one", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("0"),
-					v1.NewCluster().ID("1"),
+					cmv1.NewCluster().ID("0"),
+					cmv1.NewCluster().ID("1"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -143,20 +143,20 @@ var _ = Describe("Type", func() {
 
 	Describe("Len", func() {
 		It("Returns zero for nil list ", func() {
-			var list *v1.ClusterList
+			var list *cmv1.ClusterList
 			Expect(list.Len()).To(BeZero())
 		})
 
 		It("Returns zero for empty list ", func() {
-			list, err := v1.NewClusterList().Build()
+			list, err := cmv1.NewClusterList().Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Len()).To(BeZero())
 		})
 
 		It("Returns one for list with one element", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("123"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -164,10 +164,10 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns two for list with two elements", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
-					v1.NewCluster().ID("456"),
+					cmv1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("456"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -177,18 +177,18 @@ var _ = Describe("Type", func() {
 
 	Describe("Empty", func() {
 		It("Returns `true` for nil object ", func() {
-			var object *v1.Cluster
+			var object *cmv1.Cluster
 			Expect(object.Empty()).To(BeTrue())
 		})
 
 		It("Returns `true` for an empty object", func() {
-			object, err := v1.NewCluster().Build()
+			object, err := cmv1.NewCluster().Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(object.Empty()).To(BeTrue())
 		})
 
 		It("Returns `false` for an object with identifier", func() {
-			object, err := v1.NewCluster().
+			object, err := cmv1.NewCluster().
 				ID("123").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -196,7 +196,7 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns `false` for an object with an string attribute", func() {
-			object, err := v1.NewCluster().
+			object, err := cmv1.NewCluster().
 				Name("mycluster").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -204,20 +204,20 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns `true` for nil list ", func() {
-			var list *v1.ClusterList
+			var list *cmv1.ClusterList
 			Expect(list.Empty()).To(BeTrue())
 		})
 
 		It("Returns `true` for empty list ", func() {
-			list, err := v1.NewClusterList().Build()
+			list, err := cmv1.NewClusterList().Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Empty()).To(BeTrue())
 		})
 
 		It("Returns `false` for list with one element", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("123"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -225,10 +225,10 @@ var _ = Describe("Type", func() {
 		})
 
 		It("Returns `false` for list with two elements", func() {
-			list, err := v1.NewClusterList().
+			list, err := cmv1.NewClusterList().
 				Items(
-					v1.NewCluster().ID("123"),
-					v1.NewCluster().ID("456"),
+					cmv1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("456"),
 				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This patch changes the tests so that they use `cmv1` instead of `v1` as
the package selector for the API packages. This will simplify
introduction of other API packages in future patches.