### PR TITLE
Improve map support

### DIFF
--- a/pkg/generators/types.go
+++ b/pkg/generators/types.go
@@ -325,12 +325,14 @@ func (g *TypesGenerator) generateStructTypeSource(typ *concepts.Type) {
 				{{ end }}
 				{{ range .Type.Attributes }}
 					{{ $fieldName := fieldName . }}
-					{{ if or .Type.IsList .Type.IsMap }}
+					{{ if or .Type.IsList }}
 						{{ if .Type.Element.IsScalar }}
-							o.{{ $fieldName }} == nil &&
+							len(o.{{ $fieldName }}) == 0 &&
 						{{ else }}
 							o.{{ $fieldName }}.Empty() &&
 						{{ end }}
+					{{ else if or .Type.IsMap }}
+						len(o.{{ $fieldName }}) == 0 &&
 					{{ else }}
 						o.{{ $fieldName }} == nil &&
 					{{ end }}

--- a/pkg/golang/types.go
+++ b/pkg/golang/types.go
@@ -199,7 +199,7 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 	}
 }
 
-// NullablerReference calculates a type reference for a value of the given type that can be assigned
+// NullableReference calculates a type reference for a value of the given type that can be assigned
 // the nil value.
 func (c *TypesCalculator) NullableReference(typ *concepts.Type) *TypeReference {
 	switch {
@@ -235,10 +235,8 @@ func (c *TypesCalculator) NullableReference(typ *concepts.Type) *TypeReference {
 			ref.text = fmt.Sprintf("map[string]%s", ref.text)
 			return ref
 		case element.IsStruct():
-			ref := new(TypeReference)
-			ref.imprt, ref.selector = c.Package(element)
-			ref.name = c.names.Public(names.Cat(element.Name(), nomenclator.Map))
-			ref.text = fmt.Sprintf("*%s.%s", ref.selector, ref.name)
+			ref := c.ValueReference(element)
+			ref.text = fmt.Sprintf("map[string]*%s", ref.text)
 			return ref
 		default:
 			c.reporter.Errorf(
@@ -288,12 +286,8 @@ func (c *TypesCalculator) DataReference(typ *concepts.Type) *TypeReference {
 		case element.IsScalar():
 			return c.NullableReference(typ)
 		case element.IsStruct():
-			ref := new(TypeReference)
-			ref.imprt, ref.selector = c.Package(element)
-			ref.name = c.names.Private(names.Cat(
-				element.Name(), nomenclator.Map, nomenclator.Data),
-			)
-			ref.text = fmt.Sprintf("%s.%s", ref.selector, ref.name)
+			ref := c.DataReference(element)
+			ref.text = fmt.Sprintf("map[string]%s", ref.text)
 			return ref
 		default:
 			c.reporter.Errorf(

--- a/tests/builders_test.go
+++ b/tests/builders_test.go
@@ -22,94 +22,180 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Builder", func() {
-	It("Can set empty string list attribute", func() {
-		object, err := cmv1.NewGithubIdentityProvider().
-			Teams().
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		slice := object.Teams()
-		Expect(slice).ToNot(BeNil())
-		Expect(slice).To(BeEmpty())
-	})
+	Describe("Build", func() {
+		It("Can set empty string list attribute", func() {
+			object, err := cmv1.NewGithubIdentityProvider().
+				Teams().
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			slice := object.Teams()
+			Expect(slice).ToNot(BeNil())
+			Expect(slice).To(BeEmpty())
+		})
 
-	It("Can set string list attribute with one value", func() {
-		object, err := cmv1.NewGithubIdentityProvider().
-			Teams("a-team").
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		slice := object.Teams()
-		Expect(slice).ToNot(BeNil())
-		Expect(slice).To(HaveLen(1))
-		Expect(slice[0]).To(Equal("a-team"))
-	})
+		It("Can set string list attribute with one value", func() {
+			object, err := cmv1.NewGithubIdentityProvider().
+				Teams("a-team").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			slice := object.Teams()
+			Expect(slice).ToNot(BeNil())
+			Expect(slice).To(HaveLen(1))
+			Expect(slice[0]).To(Equal("a-team"))
+		})
 
-	It("Can set string list attribute with two values", func() {
-		object, err := cmv1.NewGithubIdentityProvider().
-			Teams("a-team", "b-team").
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		slice := object.Teams()
-		Expect(slice).ToNot(BeNil())
-		Expect(slice).To(HaveLen(2))
-		Expect(slice[0]).To(Equal("a-team"))
-		Expect(slice[1]).To(Equal("b-team"))
-	})
+		It("Can set string list attribute with two values", func() {
+			object, err := cmv1.NewGithubIdentityProvider().
+				Teams("a-team", "b-team").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			slice := object.Teams()
+			Expect(slice).ToNot(BeNil())
+			Expect(slice).To(HaveLen(2))
+			Expect(slice[0]).To(Equal("a-team"))
+			Expect(slice[1]).To(Equal("b-team"))
+		})
 
-	It("Can set empty struct list attribute", func() {
-		object, err := cmv1.NewCluster().
-			Groups().
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		list := object.Groups()
-		Expect(list).ToNot(BeNil())
-		Expect(list.Empty()).To(BeTrue())
-	})
+		It("Can set empty struct list attribute", func() {
+			object, err := cmv1.NewCluster().
+				Groups().
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			list := object.Groups()
+			Expect(list).ToNot(BeNil())
+			Expect(list.Empty()).To(BeTrue())
+		})
 
-	It("Can set struct list attribute with one value", func() {
-		object, err := cmv1.NewCluster().
-			Groups(
-				cmv1.NewGroup().ID("a-group"),
-			).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		list := object.Groups()
-		Expect(list).ToNot(BeNil())
-		Expect(list.Len()).To(Equal(1))
-		slice := list.Slice()
-		Expect(slice).ToNot(BeEmpty())
-		Expect(slice).To(HaveLen(1))
-		Expect(slice[0]).ToNot(BeNil())
-		Expect(slice[0].ID()).To(Equal("a-group"))
-	})
+		It("Can set struct list attribute with one value", func() {
+			object, err := cmv1.NewCluster().
+				Groups(
+					cmv1.NewGroup().ID("a-group"),
+				).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			list := object.Groups()
+			Expect(list).ToNot(BeNil())
+			Expect(list.Len()).To(Equal(1))
+			slice := list.Slice()
+			Expect(slice).ToNot(BeEmpty())
+			Expect(slice).To(HaveLen(1))
+			Expect(slice[0]).ToNot(BeNil())
+			Expect(slice[0].ID()).To(Equal("a-group"))
+		})
 
-	It("Can set struct list attribute with two values", func() {
-		object, err := cmv1.NewCluster().
-			Groups(
-				cmv1.NewGroup().ID("a-group"),
-				cmv1.NewGroup().ID("b-group"),
-			).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(object).ToNot(BeNil())
-		list := object.Groups()
-		Expect(list).ToNot(BeNil())
-		Expect(list.Len()).To(Equal(2))
-		slice := list.Slice()
-		Expect(slice).ToNot(BeEmpty())
-		Expect(slice).To(HaveLen(2))
-		Expect(slice[0]).ToNot(BeNil())
-		Expect(slice[0].ID()).To(Equal("a-group"))
-		Expect(slice[1]).ToNot(BeNil())
-		Expect(slice[1].ID()).To(Equal("b-group"))
+		It("Can set struct list attribute with two values", func() {
+			object, err := cmv1.NewCluster().
+				Groups(
+					cmv1.NewGroup().ID("a-group"),
+					cmv1.NewGroup().ID("b-group"),
+				).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+			list := object.Groups()
+			Expect(list).ToNot(BeNil())
+			Expect(list.Len()).To(Equal(2))
+			slice := list.Slice()
+			Expect(slice).ToNot(BeEmpty())
+			Expect(slice).To(HaveLen(2))
+			Expect(slice[0]).ToNot(BeNil())
+			Expect(slice[0].ID()).To(Equal("a-group"))
+			Expect(slice[1]).ToNot(BeNil())
+			Expect(slice[1].ID()).To(Equal("b-group"))
+		})
+
+		It("Can set empty map of strings", func() {
+			object, err := cmv1.NewCluster().
+				Properties(map[string]string{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := object.Properties()
+			Expect(properties).To(BeEmpty())
+		})
+
+		It("Can set map of strings with one value", func() {
+			object, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey": "myvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := object.Properties()
+			Expect(properties).To(HaveLen(1))
+			Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+		})
+
+		It("Can set map of strings with two values", func() {
+			object, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey":   "myvalue",
+					"yourkey": "yourvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := object.Properties()
+			Expect(properties).To(HaveLen(2))
+			Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+			Expect(properties).To(HaveKeyWithValue("yourkey", "yourvalue"))
+		})
+
+		It("Can set empty map of objects", func() {
+			object, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := object.Auths()
+			Expect(auths).To(BeEmpty())
+		})
+
+		It("Can set map of objects with one value", func() {
+			object, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com": amv1.NewAuth().Username("myuser").Email("mymail"),
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := object.Auths()
+			Expect(auths).To(HaveLen(1))
+			auth := auths["my.com"]
+			Expect(auth).ToNot(BeNil())
+			Expect(auth.Username()).To(Equal("myuser"))
+			Expect(auth.Email()).To(Equal("mymail"))
+		})
+
+		It("Can set map of objects with two values", func() {
+			object, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com": amv1.NewAuth().
+						Username("myuser").
+						Email("mymail"),
+					"your.com": amv1.NewAuth().
+						Username("youruser").
+						Email("yourmail"),
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := object.Auths()
+			Expect(auths).To(HaveLen(2))
+			first := auths["my.com"]
+			Expect(first).ToNot(BeNil())
+			Expect(first.Username()).To(Equal("myuser"))
+			Expect(first.Email()).To(Equal("mymail"))
+			second := auths["your.com"]
+			Expect(second).ToNot(BeNil())
+			Expect(second.Username()).To(Equal("youruser"))
+			Expect(second.Email()).To(Equal("yourmail"))
+		})
 	})
 
 	Describe("Copy", func() {
@@ -141,6 +227,113 @@ var _ = Describe("Builder", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(replica.ID()).To(Equal("123"))
 			Expect(replica.Name()).To(Equal("my"))
+		})
+
+		It("Copies empty map of strings", func() {
+			original, err := cmv1.NewCluster().
+				Properties(map[string]string{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := cmv1.NewCluster().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := replica.Properties()
+			Expect(properties).To(BeEmpty())
+		})
+
+		It("Copies map of strings with one value", func() {
+			original, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey": "myvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := cmv1.NewCluster().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := replica.Properties()
+			Expect(properties).To(HaveLen(1))
+			Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+		})
+
+		It("Copies map of strings with two values", func() {
+			original, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey":   "myvalue",
+					"yourkey": "yourvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := cmv1.NewCluster().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			properties := replica.Properties()
+			Expect(properties).To(HaveLen(2))
+			Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+			Expect(properties).To(HaveKeyWithValue("yourkey", "yourvalue"))
+		})
+
+		It("Copies empty map of objects", func() {
+			original, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := amv1.NewAccessToken().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := replica.Auths()
+			Expect(auths).To(BeEmpty())
+		})
+
+		It("Copies map of objects with one value", func() {
+			original, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com": amv1.NewAuth().Username("myuser").Email("mymail"),
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := amv1.NewAccessToken().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := replica.Auths()
+			Expect(auths).To(HaveLen(1))
+			auth := auths["my.com"]
+			Expect(auth).ToNot(BeNil())
+			Expect(auth.Username()).To(Equal("myuser"))
+			Expect(auth.Email()).To(Equal("mymail"))
+		})
+
+		It("Copies map of objects with two values", func() {
+			original, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com": amv1.NewAuth().
+						Username("myuser").
+						Email("mymail"),
+					"your.com": amv1.NewAuth().
+						Username("youruser").
+						Email("yourmail"),
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			replica, err := amv1.NewAccessToken().
+				Copy(original).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			auths := replica.Auths()
+			Expect(auths).To(HaveLen(2))
+			first := auths["my.com"]
+			Expect(first).ToNot(BeNil())
+			Expect(first.Username()).To(Equal("myuser"))
+			Expect(first.Email()).To(Equal("mymail"))
+			second := auths["your.com"]
+			Expect(second).ToNot(BeNil())
+			Expect(second.Username()).To(Equal("youruser"))
+			Expect(second.Email()).To(Equal("yourmail"))
 		})
 	})
 })

--- a/tests/client_tests.go
+++ b/tests/client_tests.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the methods and send requests and receive responses.
+
+package tests
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+
+	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
+)
+
+var _ = Describe("Client", func() {
+	var server *Server
+	var transport http.RoundTripper
+
+	BeforeEach(func() {
+		server = NewServer()
+		transport = NewTransport(server)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("Can read response with empty map of objects", func() {
+		server.AppendHandlers(RespondWith(http.StatusOK, `{
+			"auths": {}
+		}`))
+		client := amv1.NewAccessTokenClient(transport, "", "")
+		response, err := client.Post().Send()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		token := response.Body()
+		Expect(token).ToNot(BeNil())
+		auths := token.Auths()
+		Expect(auths).To(BeEmpty())
+	})
+
+	It("Can read response with map of objects with one value", func() {
+		server.AppendHandlers(RespondWith(http.StatusOK, `{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				}
+			}
+		}`))
+		client := amv1.NewAccessTokenClient(transport, "", "")
+		response, err := client.Post().Send()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		token := response.Body()
+		Expect(token).ToNot(BeNil())
+		auths := token.Auths()
+		Expect(auths).To(HaveLen(1))
+		auth := auths["my.com"]
+		Expect(auth).ToNot(BeNil())
+		Expect(auth.Username()).To(Equal("myuser"))
+		Expect(auth.Email()).To(Equal("mymail"))
+	})
+
+	It("Can read response with map of objects with two values", func() {
+		server.AppendHandlers(RespondWith(http.StatusOK, `{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				},
+				"your.com": {
+					"username": "youruser",
+					"email": "yourmail"
+				}
+			}
+		}`))
+		client := amv1.NewAccessTokenClient(transport, "", "")
+		response, err := client.Post().Send()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		token := response.Body()
+		Expect(token).ToNot(BeNil())
+		auths := token.Auths()
+		Expect(auths).To(HaveLen(2))
+		first := auths["my.com"]
+		Expect(first).ToNot(BeNil())
+		Expect(first.Username()).To(Equal("myuser"))
+		Expect(first.Email()).To(Equal("mymail"))
+		second := auths["your.com"]
+		Expect(second).ToNot(BeNil())
+		Expect(second.Username()).To(Equal("youruser"))
+		Expect(second.Email()).To(Equal("yourmail"))
+	})
+})
+
+// NewTransport creates an instance of the transport that will be used by the tests to talk to the
+// tests server.
+func NewTransport(server *Server) http.RoundTripper {
+	return &Transport{
+		server: server,
+		wrapped: &http.Transport{},
+	}
+}
+
+// Transport is the transport that will be used by the tests to talk to the tests server. It takes
+// care of basic things like adding the server address to the path calculated by the client.
+type Transport struct {
+	server *Server
+	wrapped *http.Transport
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *Transport) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	request.URL.Scheme = "http"
+	request.URL.Host = t.server.Addr()
+	response, err = t.wrapped.RoundTrip(request)
+	return
+}
+

--- a/tests/model/accounts_mgmt/v1/auth_type.model
+++ b/tests/model/accounts_mgmt/v1/auth_type.model
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-struct AccessToken {
-	Auths [string]Auth
+struct Auth {
+	Username string
+	Email string
 }

--- a/tests/readers_test.go
+++ b/tests/readers_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
@@ -314,5 +315,100 @@ var _ = Describe("Reader", func() {
 		Expect(slice[1].Kind()).To(Equal(cmv1.GroupKind))
 		Expect(slice[1].HREF()).To(Equal("/api/clusters_mgmt/v1/clusters/123/groups/789"))
 		Expect(slice[1].ID()).To(Equal("789"))
+	})
+
+	It("Can read empty map of strings", func() {
+		object, err := cmv1.UnmarshalCluster(`{
+			"properties": {}
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		properties := object.Properties()
+		Expect(properties).ToNot(BeNil())
+		Expect(properties).To(BeEmpty())
+	})
+
+	It("Can read map of strings with one value", func() {
+		object, err := cmv1.UnmarshalCluster(`{
+			"properties": {
+				"mykey": "myvalue"
+			}
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		properties := object.Properties()
+		Expect(properties).ToNot(BeNil())
+		Expect(properties).To(HaveLen(1))
+		Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+	})
+
+	It("Can read map of strings with two values", func() {
+		object, err := cmv1.UnmarshalCluster(`{
+			"properties": {
+				"mykey": "myvalue",
+				"yourkey": "yourvalue"
+			}
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		properties := object.Properties()
+		Expect(properties).ToNot(BeNil())
+		Expect(properties).To(HaveLen(2))
+		Expect(properties).To(HaveKeyWithValue("mykey", "myvalue"))
+		Expect(properties).To(HaveKeyWithValue("yourkey", "yourvalue"))
+	})
+
+	It("Can read empty map of objects", func() {
+		object, err := amv1.UnmarshalAccessToken(`{}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+	})
+
+	It("Can read map of objects with one value", func() {
+		object, err := amv1.UnmarshalAccessToken(`{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				}
+			}
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		auths := object.Auths()
+		Expect(auths).ToNot(BeNil())
+		Expect(auths).To(HaveLen(1))
+		auth := auths["my.com"]
+		Expect(auth).ToNot(BeNil())
+		Expect(auth.Username()).To(Equal("myuser"))
+		Expect(auth.Email()).To(Equal("mymail"))
+	})
+
+	It("Can read map of objects with two values", func() {
+		object, err := amv1.UnmarshalAccessToken(`{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				},
+				"your.com": {
+					"username": "youruser",
+					"email": "yourmail"
+				}
+			}
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		auths := object.Auths()
+		Expect(auths).ToNot(BeNil())
+		Expect(auths).To(HaveLen(2))
+		first := auths["my.com"]
+		Expect(first).ToNot(BeNil())
+		Expect(first.Username()).To(Equal("myuser"))
+		Expect(first.Email()).To(Equal("mymail"))
+		second := auths["your.com"]
+		Expect(second).ToNot(BeNil())
+		Expect(second.Username()).To(Equal("youruser"))
+		Expect(second.Email()).To(Equal("yourmail"))
 	})
 })

--- a/tests/types_test.go
+++ b/tests/types_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
@@ -230,6 +231,64 @@ var _ = Describe("Type", func() {
 					cmv1.NewCluster().ID("123"),
 					cmv1.NewCluster().ID("456"),
 				).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `true` for empty map of strings", func() {
+			list, err := cmv1.NewCluster().
+				Properties(map[string]string{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeTrue())
+		})
+
+		It("Returns `false` for map of strings with one value", func() {
+			list, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey": "myvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of strings with two values", func() {
+			list, err := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey":   "myvalue",
+					"yourkey": "yourvalue",
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `true` for empty map of objects", func() {
+			list, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeTrue())
+		})
+
+		It("Returns `false` for map of objects with one value", func() {
+			list, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com": amv1.NewAuth().Username("myuser"),
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of objects with one value", func() {
+			list, err := amv1.NewAccessToken().
+				Auths(map[string]*amv1.AuthBuilder{
+					"my.com":   amv1.NewAuth().Username("myuser"),
+					"your.com": amv1.NewAuth().Username("youruser"),
+				}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Empty()).To(BeFalse())

--- a/tests/writers_test.go
+++ b/tests/writers_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the methods that write objects to streams.
+
+package tests
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+)
+
+var _ = Describe("Writer", func() {
+	It("Can write empty map of strings", func() {
+		object, err := cmv1.NewCluster().
+			Properties(map[string]string{}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = cmv1.MarshalCluster(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"kind": "Cluster"
+		}`))
+	})
+
+	It("Can write map of strings with one value", func() {
+		object, err := cmv1.NewCluster().
+			Properties(map[string]string{
+				"mykey": "myvalue",
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = cmv1.MarshalCluster(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"kind": "Cluster",
+			"properties": {
+				"mykey": "myvalue"
+			}
+		}`))
+	})
+
+	It("Can write map of strings with two value", func() {
+		object, err := cmv1.NewCluster().
+			Properties(map[string]string{
+				"mykey":   "myvalue",
+				"yourkey": "yourvalue",
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = cmv1.MarshalCluster(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"kind": "Cluster",
+			"properties": {
+				"mykey": "myvalue",
+				"yourkey": "yourvalue"
+			}
+		}`))
+	})
+
+	It("Can write empty map of objects", func() {
+		object, err := amv1.NewAccessToken().
+			Auths(map[string]*amv1.AuthBuilder{}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = amv1.MarshalAccessToken(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{}`))
+	})
+
+	It("Can write map of objects with one value", func() {
+		object, err := amv1.NewAccessToken().
+			Auths(map[string]*amv1.AuthBuilder{
+				"my.com": amv1.NewAuth().Username("myuser").Email("mymail"),
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = amv1.MarshalAccessToken(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				}
+			}
+		}`))
+	})
+
+	It("Can write map of objects with two values", func() {
+		object, err := amv1.NewAccessToken().
+			Auths(map[string]*amv1.AuthBuilder{
+				"my.com":   amv1.NewAuth().Username("myuser").Email("mymail"),
+				"your.com": amv1.NewAuth().Username("youruser").Email("yourmail"),
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = amv1.MarshalAccessToken(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"auths": {
+				"my.com": {
+					"username": "myuser",
+					"email": "mymail"
+				},
+				"your.com": {
+					"username": "youruser",
+					"email": "yourmail"
+				}
+			}
+		}`))
+	})
+})


### PR DESCRIPTION
This patch improves the support for attributes whose type is a map where
the key is a string and the value is an struct. This means that now
types like the following can be used:

```
struct AccessToken {
	Auths [string]Auth
}

struct Auth {
	Username string
	Email string
}
```

The JSON representation for these types will be like this:

```json
{
  "auths": {
    "my.com": {
      "username": "myuser",
      "email": "mymail"
    },
    "your.com": {
      "username": "youruser",
      "email": "yourmail"
    }
}
```

In the generated code these types will be built like this:

```go
token, err := amv1.NewAccessToken().
	Auths(map[string]*amv1.AuthBuilder{
		"my.com": amv1.NewAuth().
			Username("myuser").
			Email("mymail"),
		"your.com": amv1.NewAuth().
			Username("youruser").
			Email("yourmail"),
	}).
	Build()
if err != nil {
	...
}
```