### PR TITLE
Shorter _read_ and _write_ names

### DIFF
--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -106,4 +106,5 @@ var (
 
 	// W:
 	Wrap = names.ParseUsingCase("Wrap")
+	Write = names.ParseUsingCase("Write")
 )


### PR DESCRIPTION
This patch changes the code generator so that it produces shorter names
for the methods that requests and write responses.