### PR TITLE
Set default status

### DIFF
--- a/pkg/generators/servers.go
+++ b/pkg/generators/servers.go
@@ -190,6 +190,7 @@ func (g *ServersGenerator) generateResourceServerFile(resource *concepts.Resourc
 		Function("httpMethod", g.httpMethod).
 		Function("locatorHandlerName", g.locatorHandlerName).
 		Function("locatorName", g.locatorName).
+		Function("methodHandlerName", g.methodHandlerName).
 		Function("methodName", g.methodName).
 		Function("queryParameterName", g.queryParameterName).
 		Function("readRequestName", g.readRequestName).
@@ -299,7 +300,7 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 			{{ end }}
 
 			{{ range .Resource.Methods }}
-				adapter.router.Methods({{ httpMethod . }}).Path("").HandlerFunc(adapter.{{ .Name }}Handler)
+				adapter.router.Methods({{ httpMethod . }}).Path("").HandlerFunc(adapter.{{ methodHandlerName . }})
 			{{ end }}
 			return adapter
 		}
@@ -322,7 +323,7 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 					target := a.server.{{ $locatorName }}()
 					targetAdapter := New{{ $targerAdapterName }}(target, a.router.PathPrefix("/{{ $locatorURLSegment }}").Subrouter())
 					targetAdapter.ServeHTTP(w,r)
-					return 
+					return
 				{{ end }}
 			}
 		{{ end }}
@@ -337,7 +338,7 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 			{{ $requestQueryParameters := requestQueryParameters . }}
 			{{ $readRequestName := readRequestName . }}
 			{{ $writeResponseName := writeResponseName . }}
-	
+
 			func (a *{{ $adapterName }}) {{ $readRequestName }}(r *http.Request) (*{{ $requestName }}, error) {
 				var err error
 				result := new({{ $requestName }})
@@ -362,7 +363,6 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 				return result, err
 			}
 
-
 			func (a *{{ $adapterName }}) {{ $writeResponseName }}(w http.ResponseWriter, r *{{ $responseName }}) error {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(r.status)
@@ -372,39 +372,48 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 						return err
 					}
 				{{ end }}
-				return nil	
+				return nil
 			}
 
-			func (a *{{ $adapterName }} ) {{ .Name }}Handler (w http.ResponseWriter, r *http.Request) {
-				req, err := a.{{ $readRequestName }}(r)
-					if err != nil {
-						reason := fmt.Sprintf("An error occured while trying to read request from client: %v", err)
-						errorBody, _ := errors.NewError().
-							Reason(reason).
-							ID("500").
-							Build()
-						errors.SendError(w, r, errorBody)
-						return										
-					}
-					resp := new({{ $responseName }})
-					err = a.server.{{ $methodName }}(r.Context(), req, resp)
-					if err != nil {
-						reason := fmt.Sprintf("An error occured while trying to run method {{ $methodName }}: %v", err)
-						errorBody, _ := errors.NewError().
-							Reason(reason).
-							ID("500").
-							Build()
-						errors.SendError(w, r, errorBody)
-					}
-					err = a.{{ $writeResponseName }}(w, resp)
-					if err != nil {
-						reason := fmt.Sprintf("An error occured while trying to write response for client: %v", err)
-						errorBody, _ := errors.NewError().
-							Reason(reason).
-							ID("500").
-							Build()
-						errors.SendError(w, r, errorBody)
-					}
+			func (a *{{ $adapterName }} ) {{ methodHandlerName . }}(w http.ResponseWriter, r *http.Request) {
+				request, err := a.{{ $readRequestName }}(r)
+				if err != nil {
+					reason := fmt.Sprintf(
+						"An error occurred while trying to read request from client: %v",
+						err,
+					)
+					body, _ := errors.NewError().
+						Reason(reason).
+						ID("500").
+						Build()
+					errors.SendError(w, r, body)
+					return
+				}
+				response := new({{ $responseName }})
+				err = a.server.{{ $methodName }}(r.Context(), request, response)
+				if err != nil {
+					reason := fmt.Sprintf(
+						"An error occurred while trying to run method {{ $methodName }}: %v",
+						err,
+					)
+					body, _ := errors.NewError().
+						Reason(reason).
+						ID("500").
+						Build()
+					errors.SendError(w, r, body)
+				}
+				err = a.{{ $writeResponseName }}(w, response)
+				if err != nil {
+					reason := fmt.Sprintf(
+						"An error occurred while trying to write response for client: %v",
+						err,
+					)
+					body, _ := errors.NewError().
+						Reason(reason).
+						ID("500").
+						Build()
+					errors.SendError(w, r, body)
+				}
 			}
 		{{ end }}
 
@@ -547,7 +556,7 @@ func (g *ServersGenerator) generateResponseSource(method *concepts.Method) {
 				{{ fieldName . }} {{ fieldType . }}
 			{{ end }}
 		}
-		
+
 		{{ range $responseParameters }}
 			{{ $fieldName := fieldName . }}
 			{{ $setterName := setterName . }}
@@ -565,7 +574,7 @@ func (g *ServersGenerator) generateResponseSource(method *concepts.Method) {
 				return r
 			}
 		{{ end }}
-		
+
 		// Status sets the status code.
 		func (r *{{ $responseName }}) Status(value int) *{{ $responseName }} {
 			r.status = value
@@ -659,6 +668,11 @@ func (g *ServersGenerator) urlSegment(name *names.Name) string {
 
 func (g *ServersGenerator) methodName(method *concepts.Method) string {
 	return g.names.Public(method.Name())
+}
+
+func (g *ServersGenerator) methodHandlerName(method *concepts.Method) string {
+	name := names.Cat(nomenclator.Handler, method.Name())
+	return g.names.Private(name)
 }
 
 func (g *ServersGenerator) readRequestName(method *concepts.Method) string {

--- a/pkg/generators/servers.go
+++ b/pkg/generators/servers.go
@@ -182,6 +182,7 @@ func (g *ServersGenerator) generateResourceServerFile(resource *concepts.Resourc
 		Function("dataFieldName", g.dataFieldName).
 		Function("dataFieldType", g.dataFieldType).
 		Function("dataStruct", g.dataStruct).
+		Function("defaultHttpStatus", g.defaultHttpStatus).
 		Function("fieldName", g.fieldName).
 		Function("fieldTag", g.fieldTag).
 		Function("fieldType", g.fieldType).
@@ -390,6 +391,7 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 					return
 				}
 				response := new({{ $responseName }})
+				response.status = {{ defaultHttpStatus . }}
 				err = a.server.{{ $methodName }}(r.Context(), request, response)
 				if err != nil {
 					reason := fmt.Sprintf(
@@ -854,6 +856,11 @@ func (g *ServersGenerator) httpMethod(method *concepts.Method) string {
 	default:
 		return "http.MethodGet"
 	}
+}
+
+func (g *ServersGenerator) defaultHttpStatus(method *concepts.Method) string {
+	// Set 200 as the default for all methods for now.
+	return "http.StatusOK"
 }
 
 func (g *ServersGenerator) readerName(typ *concepts.Type) string {

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -46,9 +46,6 @@ func (s *MyTestClustersServer) List(ctx context.Context, request *cmv1.ClustersL
 	if err != nil {
 		return err
 	}
-	// Set a status code 200. Return empty response.
-	response.Status(http.StatusOK)
-	// Set body of response
 	response.Items(items)
 	response.Page(request.Page())
 	response.Size(request.Size())
@@ -58,8 +55,6 @@ func (s *MyTestClustersServer) List(ctx context.Context, request *cmv1.ClustersL
 
 func (s *MyTestClustersServer) Add(ctx context.Context, request *cmv1.ClustersAddServerRequest,
 	response *cmv1.ClustersAddServerResponse) error {
-	// Set a status code 200. Return empty response.
-	response.Status(http.StatusOK)
 	return nil
 }
 
@@ -71,7 +66,6 @@ type MyTestClusterServer struct{}
 
 func (s *MyTestClusterServer) Get(ctx context.Context, request *cmv1.ClusterGetServerRequest,
 	response *cmv1.ClusterGetServerResponse) error {
-	response.Status(http.StatusOK)
 	cluster, err := cmv1.NewCluster().Name("test-get-cluster-by-id").Build()
 	if err != nil {
 		return err
@@ -82,13 +76,11 @@ func (s *MyTestClusterServer) Get(ctx context.Context, request *cmv1.ClusterGetS
 
 func (s *MyTestClusterServer) Update(ctx context.Context, request *cmv1.ClusterUpdateServerRequest,
 	response *cmv1.ClusterUpdateServerResponse) error {
-	response.Status(http.StatusOK)
 	return nil
 }
 
 func (s *MyTestClusterServer) Delete(ctx context.Context, request *cmv1.ClusterDeleteServerRequest,
 	response *cmv1.ClusterDeleteServerResponse) error {
-	response.Status(http.StatusOK)
 	return nil
 }
 
@@ -111,9 +103,6 @@ func (s *MyTestIdentityProvidersServer) List(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	// Set a status code 200. Return empty response.
-	response.Status(http.StatusOK)
-	// Set body of response
 	response.Items(items)
 	response.Page(1)
 	response.Size(1)


### PR DESCRIPTION
Currently the code generated for servers requires implementations to set
a status code, otherwise it will be 0 and the Go HTTP library will
generate an error. To avoid that this patch changes the generated code
so that it always sets a default value.