### PR TITLE
Release 0.0.9

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,16 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.9 Oct 15 2019
+
+- Generate shorter adapter names.
+- Use constants from the `http` package.
+- Shorter _read_ and _write_ names.
+- Rename `SetStatusCode` to `Status`.
+- Improve naming of variables.
+- Set default status.
+- Move errors and helpers generators to separate files.
+
 == 0.0.8 Oct 12 2019
 
 - Use a private model for tests.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.8"
+const Version = "0.0.9"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Generate shorter adapter names.
- Use constants from the `http` package.
- Shorter _read_ and _write_ names.
- Rename `SetStatusCode` to `Status`.
- Improve naming of variables.
- Set default status.
- Move errors and helpers generators to separate files.