### PR TITLE
Stateless adapters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/antlr/antlr4 v0.0.0-20181218183524-be58ebffde8e
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.9.0
 	github.com/onsi/gomega v1.5.0
 	github.com/openshift-online/ocm-sdk-go v0.1.43

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -24,16 +23,13 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -87,7 +83,6 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190322120337-addf6b3196f6 h1:78jEq2G3J16aXneH23HSnTQQTCwMHoyO8VEiUH+bpPM=
 golang.org/x/net v0.0.0-20190322120337-addf6b3196f6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -102,7 +97,6 @@ golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -85,6 +85,28 @@ func (r *Resource) Locators() LocatorSlice {
 	return r.locators
 }
 
+// VariableLocator returns the variable locator of the resource. If there is no such resource it
+// returns nil.
+func (r *Resource) VariableLocator() *Locator {
+	for _, locator := range r.locators {
+		if locator.Variable() {
+			return locator
+		}
+	}
+	return nil
+}
+
+// ConstantLocators returns the constant (non variable) locators of the resuurce.
+func (r *Resource) ConstantLocators() LocatorSlice {
+	locators := LocatorSlice{}
+	for _, locator := range r.locators {
+		if !locator.Variable() {
+			locators = append(locators, locator)
+		}
+	}
+	return locators
+}
+
 // AddLocator adds a locator to the resource.
 func (r *Resource) AddLocator(locator *Locator) {
 	if locator != nil {

--- a/pkg/generators/errors.go
+++ b/pkg/generators/errors.go
@@ -422,17 +422,15 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 			Build()
 
 		// SendError writes a given error and status code to a response writer.
-		// if an error occured it will log the error and exit.
+		// if an error occurred it will log the error and exit.
 		// This methods is used internaly and no backwards compatibily is guaranteed.
 		func SendError(w http.ResponseWriter, r *http.Request, error *Error) {
-			w.Header().Set("Content-Type", "application/json")
-
 			status, err := strconv.Atoi(error.ID())
 			if err != nil {
 				SendPanic(w, r)
 				return
 			}
-
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)
 			err = error.MarshalError(w)
 			if err != nil {
@@ -445,7 +443,6 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// This methods is used internaly and no backwards compatibily is guaranteed.
 		func SendPanic(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			// Convert it to JSON:
 			err := panicError.MarshalError(w)
 			if err != nil {
 				glog.Errorf(
@@ -454,6 +451,58 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 					err.Error(),
 				)
 			}
+		}
+
+		// SendNotFound sends a generic 404 error.
+		func SendNotFound(w http.ResponseWriter, r *http.Request) {
+			reason := fmt.Sprintf(
+				"Can't find resource for path '%s''",
+				r.URL.Path,
+			)
+			body, err := NewError().
+				ID("404").
+				Reason(reason).
+				Build()
+			if err != nil {
+				SendPanic(w, r)
+				return
+			}
+			SendError(w, r, body)
+		}
+
+		// SendMethodNotSupported sends a generic 409 error.
+		func SendMethodNotSupported(w http.ResponseWriter, r *http.Request) {
+			reason := fmt.Sprintf(
+				"Method '%s' isn't supported for path '%s''",
+				r.Method, r.URL.Path,
+			)
+			body, err := NewError().
+				ID("409").
+				Reason(reason).
+				Build()
+			if err != nil {
+				SendPanic(w, r)
+				return
+			}
+			SendError(w, r, body)
+		}
+
+		// SendInternalServerError sends a generic 500 error.
+		func SendInternalServerError(w http.ResponseWriter, r *http.Request) {
+			reason := fmt.Sprintf(
+				"Can't process '%s' request for path '%s' due to an internal"+
+					"server error",
+				r.Method, r.URL.Path,
+			)
+			body, err := NewError().
+				ID("500").
+				Reason(reason).
+				Build()
+			if err != nil {
+				SendPanic(w, r)
+				return
+			}
+			SendError(w, r, body)
 		}
         `)
 

--- a/pkg/generators/helpers.go
+++ b/pkg/generators/helpers.go
@@ -142,6 +142,7 @@ func (g *HelpersGenerator) Run() error {
 	g.buffer.Import("fmt", "")
 	g.buffer.Import("net/http", "")
 	g.buffer.Import("net/url", "")
+	g.buffer.Import("strings", "")
 	g.buffer.Import("time", "")
 	g.buffer.Emit(`
 		// AddValue creates the given set of query parameters if needed, an then adds
@@ -193,6 +194,17 @@ func (g *HelpersGenerator) Run() error {
 			result := make([]string, len(values))
 			copy(result, values)
 			return result
+		}
+
+		// Segments calculates the path segments for the given path.
+		func Segments(path string) []string {
+			for strings.HasPrefix(path, "/") {
+				path = path[1:]
+			}
+			for strings.HasSuffix(path, "/") {
+				path = path[0:len(path)-1]
+			}
+			return strings.Split(path, "/")
 		}
 
 		// Name of the header used to contain the metrics path:

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -22,8 +22,9 @@ import (
 
 var (
 	// A:
-	Add     = names.ParseUsingCase("Add")
+	Adapt   = names.ParseUsingCase("Adapt")
 	Adapter = names.ParseUsingCase("Adapter")
+	Add     = names.ParseUsingCase("Add")
 
 	// B:
 	Boolean = names.ParseUsingCase("Boolean")
@@ -34,9 +35,10 @@ var (
 	Clients = names.ParseUsingCase("Clients")
 
 	// D:
-	Data   = names.ParseUsingCase("Data")
-	Date   = names.ParseUsingCase("Date")
-	Delete = names.ParseUsingCase("Delete")
+	Data     = names.ParseUsingCase("Data")
+	Date     = names.ParseUsingCase("Date")
+	Delete   = names.ParseUsingCase("Delete")
+	Dispatch = names.ParseUsingCase("Dispatch")
 
 	// E:
 	Error  = names.ParseUsingCase("Error")

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/gorilla/mux"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
@@ -123,7 +122,7 @@ func (s *MyTestIdentityProvidersServer) IdentityProvider(id string) cmv1.Identit
 var _ = Describe("Server", func() {
 	It("Can receive a request and return response", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters", nil)
 		recorder := httptest.NewRecorder()
@@ -132,20 +131,20 @@ var _ = Describe("Server", func() {
 		Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
 	})
 
-	It("Returns a 404 for a path with a trailing slash", func() {
+	It("Returns the list of clusters with a trailing slash", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/", nil)
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
-		Expect(recorder.Result().StatusCode).To(Equal(http.StatusNotFound))
+		Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
 	})
 
 	It("Returns a 404 for an unkown resource", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/foo", nil)
 		recorder := httptest.NewRecorder()
@@ -156,7 +155,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters", nil)
 		recorder := httptest.NewRecorder()
@@ -180,7 +179,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by page", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?page=2", nil)
 		recorder := httptest.NewRecorder()
@@ -199,7 +198,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by size", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2", nil)
 		recorder := httptest.NewRecorder()
@@ -223,7 +222,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a list of clusters by size and page", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters?size=2&page=1", nil)
 		recorder := httptest.NewRecorder()
@@ -245,9 +244,9 @@ var _ = Describe("Server", func() {
 		Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
 	})
 
-	It("Can get a cluster by id", func() {
+	It("Can get a cluster by identifier", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/123", nil)
 		recorder := httptest.NewRecorder()
@@ -264,7 +263,7 @@ var _ = Describe("Server", func() {
 
 	It("Can get a cluster sub resource by id", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(
 			http.MethodGet,
@@ -292,7 +291,7 @@ var _ = Describe("Server", func() {
 
 	It("Returns a 404 for an unkown sub resource", func() {
 		myTestRootServer := new(MyTestRootServer)
-		rootAdapter := cmv1.NewRootAdapter(myTestRootServer, mux.NewRouter())
+		rootAdapter := cmv1.NewRootAdapter(myTestRootServer)
 
 		request := httptest.NewRequest(http.MethodGet, "/clusters/123/foo", nil)
 		recorder := httptest.NewRecorder()


### PR DESCRIPTION
Currently the adapters that convert HTTP requests into requests to the
implementations of th servers are stateful: they contain a reference to
the server that they use. This means that each request requires the
allocation of a new adapter for each path segment. To avoid that
unnecessary allocations this patch changes the adapters so that they are
stateless functions instead of objects.