### PR TITLE
Release 0.0.10

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.10 Oct 25 2019
+
+- Make HTTP server adapters stateless.
+
 == 0.0.9 Oct 15 2019
 
 - Generate shorter adapter names.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.9"
+const Version = "0.0.10"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Make HTTP adapters stateless.