### PR TITLE
Fix the method not allowed code

### DIFF
--- a/pkg/generators/errors.go
+++ b/pkg/generators/errors.go
@@ -470,14 +470,14 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 			SendError(w, r, body)
 		}
 
-		// SendMethodNotSupported sends a generic 409 error.
-		func SendMethodNotSupported(w http.ResponseWriter, r *http.Request) {
+		// SendMethodNotAllowed sends a generic 405 error.
+		func SendMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 			reason := fmt.Sprintf(
 				"Method '%s' isn't supported for path '%s''",
 				r.Method, r.URL.Path,
 			)
 			body, err := NewError().
-				ID("409").
+				ID("405").
 				Reason(reason).
 				Build()
 			if err != nil {

--- a/pkg/generators/servers.go
+++ b/pkg/generators/servers.go
@@ -308,7 +308,7 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 						{{ adaptRequestName . }}(w, r, server)
 				{{ end }}
 				default:
-					errors.SendMethodNotSupported(w, r)
+					errors.SendMethodNotAllowed(w, r)
 				}
 			} else {
 				switch segments[0] {


### PR DESCRIPTION
Currently the generated code sends a 409 code when a method is not
supported, but it should send 405 instead. This patch fixes that.