### PR TITLE
Send not found when server returns nil target

### DIFF
--- a/pkg/generators/servers.go
+++ b/pkg/generators/servers.go
@@ -309,22 +309,32 @@ func (g *ServersGenerator) generateAdapterSource(resource *concepts.Resource) {
 				{{ end }}
 				default:
 					errors.SendMethodNotAllowed(w, r)
+					return
 				}
 			} else {
 				switch segments[0] {
 				{{ range .Resource.ConstantLocators }}
 					case "{{ urlSegment .Name }}":
 						target := server.{{ locatorName . }}()
+						if target == nil {
+							errors.SendNotFound(w, r)
+							return
+						}
 						{{ dispatchRequestName .Target }}(w, r, target, segments[1:])
 				{{ end }}
 				default:
 					{{ if .Resource.VariableLocator }}
 						{{ with .Resource.VariableLocator }}
 							target := server.{{ locatorName . }}(segments[0])
+							if target == nil {
+								errors.SendNotFound(w, r)
+								return
+							}
 							{{ dispatchRequestName .Target }}(w, r, target, segments[1:])
 						{{ end }}
 					{{ else }}
 						errors.SendNotFound(w, r)
+						return
 					{{ end }}
 				}
 			}

--- a/tests/model/clusters_mgmt/v1/nil_resource.model
+++ b/tests/model/clusters_mgmt/v1/nil_resource.model
@@ -14,16 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources of the clusters management service.
-resource Root {
-	// Reference to the resource that manages the collection of clusters.
-	locator Clusters {
-		target Clusters
-	}
-
-	// This locator is intended to test what happens when the implementation of a locator
-	// returns nil.
-	locator Nil {
-		target Nil
-	}
+resource Nil {
 }

--- a/tests/servers_test.go
+++ b/tests/servers_test.go
@@ -35,6 +35,12 @@ func (s *MyTestRootServer) Clusters() cmv1.ClustersServer {
 	return &MyTestClustersServer{}
 }
 
+func (s *MyTestRootServer) Nil() cmv1.NilServer {
+	// This should always return nil, as it is used in the tests to check what happens when
+	// a locator returns nil.
+	return nil
+}
+
 type MyTestClustersServer struct{}
 
 func (s *MyTestClustersServer) List(ctx context.Context, request *cmv1.ClustersListServerRequest,
@@ -297,6 +303,15 @@ var _ = Describe("Server", func() {
 		recorder := httptest.NewRecorder()
 		rootAdapter.ServeHTTP(recorder, request)
 
+		Expect(recorder.Result().StatusCode).To(Equal(http.StatusNotFound))
+	})
+
+	It("Returns a 404 if the server returns nil for a locator", func() {
+		server := new(MyTestRootServer)
+		adapter := cmv1.NewRootAdapter(server)
+		request := httptest.NewRequest(http.MethodGet, "/nil", nil)
+		recorder := httptest.NewRecorder()
+		adapter.ServeHTTP(recorder, request)
 		Expect(recorder.Result().StatusCode).To(Equal(http.StatusNotFound))
 	})
 })


### PR DESCRIPTION
Currently the HTTP adaters don't check if the value returned by locators
is `nil`. That results in a panic when that happens. To avoid that this
patch changes the generated code so that will check if the returned
value is `nil` and will send a 404 error response if it is.