### PR TITLE
Don't generate files with execution permission

### DIFF
--- a/pkg/asciidoc/buffer.go
+++ b/pkg/asciidoc/buffer.go
@@ -220,7 +220,7 @@ func (b *Buffer) Write() error {
 	}
 
 	// Open the file:
-	outputFd, err := os.OpenFile(b.file, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0744)
+	outputFd, err := os.OpenFile(b.file, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
 		return fmt.Errorf("can't open output file '%s': %v", b.file, err)
 	}

--- a/pkg/golang/buffer.go
+++ b/pkg/golang/buffer.go
@@ -286,7 +286,7 @@ func (b *Buffer) Write() error {
 	}
 
 	// Open the file:
-	outputFd, err := os.OpenFile(b.file, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0744)
+	outputFd, err := os.OpenFile(b.file, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
 		return fmt.Errorf("can't open output file '%s': %v", b.file, err)
 	}


### PR DESCRIPTION
Currently the files created by the code generators have execution
permission, but they don't need it. This patch fixes that.