### PR TITLE
Release 0.0.11

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.11 Oct 27 2019
+
+- Improve parsing of initialisms.
+- Fix the method not allowed code.
+- Send not found when server returns `nil` target.
+- Generate service and version servers.
+- Don't generate files with execution permission.
+
 == 0.0.10 Oct 25 2019
 
 - Make HTTP server adapters stateless.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.10"
+const Version = "0.0.11"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Improve parsing of initialisms.
- Fix the method not allowed code.
- Send not found when server returns `nil` target.
- Generate service and version servers.
- Don't generate files with execution permission.