### PR TITLE
Replace base package with calculator

### DIFF
--- a/cmd/ocm-metamodel-tool/generate/cmd.go
+++ b/cmd/ocm-metamodel-tool/generate/cmd.go
@@ -120,7 +120,6 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	goNamesCalculator, err := golang.NewNamesCalculator().
 		Reporter(reporter).
-		Base(args.base).
 		Build()
 	if err != nil {
 		reporter.Errorf("Can't create Go names calculator: %v", err)
@@ -128,7 +127,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	goTypesCalculator, err := golang.NewTypesCalculator().
 		Reporter(reporter).
-		Base(args.base).
+		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Build()
 	if err != nil {
@@ -159,7 +158,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Build()
@@ -174,7 +172,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Build()
@@ -189,7 +186,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Types(goTypesCalculator).
@@ -205,7 +201,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Types(goTypesCalculator).
@@ -221,7 +216,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Types(goTypesCalculator).
@@ -238,7 +232,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Types(goTypesCalculator).
@@ -255,7 +248,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(goNamesCalculator).
 		Types(goTypesCalculator).
@@ -286,7 +278,6 @@ func run(cmd *cobra.Command, argv []string) {
 		Reporter(reporter).
 		Model(model).
 		Output(args.output).
-		Base(args.base).
 		Packages(goPackagesCalculator).
 		Names(openapiCalculator).
 		Binding(bindingCalculator).

--- a/pkg/generators/builders.go
+++ b/pkg/generators/builders.go
@@ -32,7 +32,6 @@ type BuildersGeneratorBuilder struct {
 	reporter *reporter.Reporter
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	types    *golang.TypesCalculator
@@ -45,7 +44,6 @@ type BuildersGenerator struct {
 	errors   int
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	types    *golang.TypesCalculator
@@ -73,12 +71,6 @@ func (b *BuildersGeneratorBuilder) Model(value *concepts.Model) *BuildersGenerat
 // Output sets the directory where the source will be generated.
 func (b *BuildersGeneratorBuilder) Output(value string) *BuildersGeneratorBuilder {
 	b.output = value
-	return b
-}
-
-// Base sets the import import path of the base output package.
-func (b *BuildersGeneratorBuilder) Base(value string) *BuildersGeneratorBuilder {
-	b.base = value
 	return b
 }
 
@@ -117,10 +109,6 @@ func (b *BuildersGeneratorBuilder) Build() (generator *BuildersGenerator, err er
 		err = fmt.Errorf("output is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base is mandatory")
-		return
-	}
 	if b.packages == nil {
 		err = fmt.Errorf("packages calculator is mandatory")
 		return
@@ -139,7 +127,6 @@ func (b *BuildersGeneratorBuilder) Build() (generator *BuildersGenerator, err er
 		reporter: b.reporter,
 		model:    b.model,
 		output:   b.output,
-		base:     b.base,
 		packages: b.packages,
 		names:    b.names,
 		types:    b.types,
@@ -193,7 +180,7 @@ func (g *BuildersGenerator) generateStructBuilderFile(typ *concepts.Type) error 
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Function("builderCtor", g.builderCtor).
@@ -442,7 +429,7 @@ func (g *BuildersGenerator) generateListBuilderFile(typ *concepts.Type) error {
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Function("builderCtor", g.builderCtor).

--- a/pkg/generators/errors.go
+++ b/pkg/generators/errors.go
@@ -32,7 +32,6 @@ type ErrorsGeneratorBuilder struct {
 	reporter *reporter.Reporter
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 }
@@ -43,7 +42,6 @@ type ErrorsGenerator struct {
 	errors   int
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	buffer   *golang.Buffer
@@ -69,12 +67,6 @@ func (b *ErrorsGeneratorBuilder) Model(value *concepts.Model) *ErrorsGeneratorBu
 // Output sets the output directory.
 func (b *ErrorsGeneratorBuilder) Output(value string) *ErrorsGeneratorBuilder {
 	b.output = value
-	return b
-}
-
-// Base sets the output base package.
-func (b *ErrorsGeneratorBuilder) Base(value string) *ErrorsGeneratorBuilder {
-	b.base = value
 	return b
 }
 
@@ -107,10 +99,6 @@ func (b *ErrorsGeneratorBuilder) Build() (generator *ErrorsGenerator, err error)
 		err = fmt.Errorf("path is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base is mandatory")
-		return
-	}
 	if b.packages == nil {
 		err = fmt.Errorf("packages calculator is mandatory")
 		return
@@ -125,7 +113,6 @@ func (b *ErrorsGeneratorBuilder) Build() (generator *ErrorsGenerator, err error)
 		reporter: b.reporter,
 		model:    b.model,
 		output:   b.output,
-		base:     b.base,
 		packages: b.packages,
 		names:    b.names,
 	}
@@ -177,7 +164,7 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Build()
@@ -535,7 +522,7 @@ func (g *ErrorsGenerator) generateVersionErrors(version *concepts.Version) error
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Function("errorName", g.errorName).

--- a/pkg/generators/helpers.go
+++ b/pkg/generators/helpers.go
@@ -31,7 +31,6 @@ type HelpersGeneratorBuilder struct {
 	reporter *reporter.Reporter
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 }
@@ -42,7 +41,6 @@ type HelpersGenerator struct {
 	errors   int
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	buffer   *golang.Buffer
@@ -69,12 +67,6 @@ func (b *HelpersGeneratorBuilder) Model(value *concepts.Model) *HelpersGenerator
 // Output sets the output directory.
 func (b *HelpersGeneratorBuilder) Output(value string) *HelpersGeneratorBuilder {
 	b.output = value
-	return b
-}
-
-// Base sets the output base package.
-func (b *HelpersGeneratorBuilder) Base(value string) *HelpersGeneratorBuilder {
-	b.base = value
 	return b
 }
 
@@ -107,10 +99,6 @@ func (b *HelpersGeneratorBuilder) Build() (generator *HelpersGenerator, err erro
 		err = fmt.Errorf("path is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base is mandatory")
-		return
-	}
 	if b.packages == nil {
 		err = fmt.Errorf("packages calculator is mandatory")
 		return
@@ -125,7 +113,6 @@ func (b *HelpersGeneratorBuilder) Build() (generator *HelpersGenerator, err erro
 		reporter: b.reporter,
 		model:    b.model,
 		output:   b.output,
-		base:     b.base,
 		packages: b.packages,
 		names:    b.names,
 	}
@@ -145,7 +132,7 @@ func (g *HelpersGenerator) Run() error {
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Build()

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -34,7 +34,6 @@ type OpenAPIGeneratorBuilder struct {
 	reporter *reporter.Reporter
 	model    *concepts.Model
 	output   string
-	base     string
 	names    *openapi.NamesCalculator
 	binding  *http.BindingCalculator
 	packages *golang.PackagesCalculator
@@ -46,7 +45,6 @@ type OpenAPIGenerator struct {
 	errors   int
 	model    *concepts.Model
 	output   string
-	base     string
 	names    *openapi.NamesCalculator
 	binding  *http.BindingCalculator
 	packages *golang.PackagesCalculator
@@ -74,12 +72,6 @@ func (b *OpenAPIGeneratorBuilder) Model(value *concepts.Model) *OpenAPIGenerator
 // Output sets the output directory.
 func (b *OpenAPIGeneratorBuilder) Output(value string) *OpenAPIGeneratorBuilder {
 	b.output = value
-	return b
-}
-
-// Base sets the import import path of the output package.
-func (b *OpenAPIGeneratorBuilder) Base(value string) *OpenAPIGeneratorBuilder {
-	b.base = value
 	return b
 }
 
@@ -118,10 +110,6 @@ func (b *OpenAPIGeneratorBuilder) Build() (generator *OpenAPIGenerator, err erro
 		err = fmt.Errorf("output directory is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base package is mandatory")
-		return
-	}
 	if b.names == nil {
 		err = fmt.Errorf("names calculator is mandatory")
 		return
@@ -140,7 +128,6 @@ func (b *OpenAPIGeneratorBuilder) Build() (generator *OpenAPIGenerator, err erro
 		reporter: b.reporter,
 		model:    b.model,
 		output:   b.output,
-		base:     b.base,
 		names:    b.names,
 		binding:  b.binding,
 		packages: b.packages,
@@ -186,7 +173,7 @@ func (g *OpenAPIGenerator) generateSpec(version *concepts.Version) error {
 	g.buffer, err = openapi.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		Build()
 	if err != nil {

--- a/pkg/generators/types.go
+++ b/pkg/generators/types.go
@@ -32,7 +32,6 @@ type TypesGeneratorBuilder struct {
 	reporter *reporter.Reporter
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	types    *golang.TypesCalculator
@@ -45,7 +44,6 @@ type TypesGenerator struct {
 	errors   int
 	model    *concepts.Model
 	output   string
-	base     string
 	packages *golang.PackagesCalculator
 	names    *golang.NamesCalculator
 	types    *golang.TypesCalculator
@@ -73,12 +71,6 @@ func (b *TypesGeneratorBuilder) Model(value *concepts.Model) *TypesGeneratorBuil
 // Output sets import path of the output package.
 func (b *TypesGeneratorBuilder) Output(value string) *TypesGeneratorBuilder {
 	b.output = value
-	return b
-}
-
-// Base sets the import import path of the output package.
-func (b *TypesGeneratorBuilder) Base(value string) *TypesGeneratorBuilder {
-	b.base = value
 	return b
 }
 
@@ -116,10 +108,6 @@ func (b *TypesGeneratorBuilder) Build() (generator *TypesGenerator, err error) {
 		err = fmt.Errorf("output is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base package is mandatory")
-		return
-	}
 	if b.packages == nil {
 		err = fmt.Errorf("packages calculator is mandatory")
 		return
@@ -138,7 +126,6 @@ func (b *TypesGeneratorBuilder) Build() (generator *TypesGenerator, err error) {
 		reporter: b.reporter,
 		model:    b.model,
 		output:   b.output,
-		base:     b.base,
 		packages: b.packages,
 		names:    b.names,
 		types:    b.types,
@@ -190,7 +177,7 @@ func (g *TypesGenerator) generateTypeFile(typ *concepts.Type) error {
 	g.buffer, err = golang.NewBufferBuilder().
 		Reporter(g.reporter).
 		Output(g.output).
-		Base(g.base).
+		Packages(g.packages).
 		Package(pkgName).
 		File(fileName).
 		Function("enumName", g.enumName).

--- a/pkg/golang/buffer.go
+++ b/pkg/golang/buffer.go
@@ -36,9 +36,9 @@ import (
 type BufferBuilder struct {
 	reporter  *reporter.Reporter
 	output    string
-	base      string
 	pkg       string
 	file      string
+	packages  *PackagesCalculator
 	functions map[string]interface{}
 }
 
@@ -47,6 +47,7 @@ type Buffer struct {
 	reporter  *reporter.Reporter
 	pkg       string
 	file      string
+	packages  *PackagesCalculator
 	functions map[string]interface{}
 	imports   map[string]string
 	code      *bytes.Buffer
@@ -69,9 +70,9 @@ func (b *BufferBuilder) Output(value string) *BufferBuilder {
 	return b
 }
 
-// Base sets the import path of the base package where the code will be generated.
-func (b *BufferBuilder) Base(value string) *BufferBuilder {
-	b.base = value
+// Packages sets the object that will be used to calculate package names.
+func (b *BufferBuilder) Packages(value *PackagesCalculator) *BufferBuilder {
+	b.packages = value
 	return b
 }
 
@@ -109,8 +110,8 @@ func (b *BufferBuilder) Build() (buffer *Buffer, err error) {
 		err = fmt.Errorf("output is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base is mandatory")
+	if b.packages == nil {
+		err = fmt.Errorf("packages calculator is mandatory")
 		return
 	}
 	if b.file == "" {
@@ -121,7 +122,7 @@ func (b *BufferBuilder) Build() (buffer *Buffer, err error) {
 	// Allocate and populate the buffer:
 	buffer = new(Buffer)
 	buffer.reporter = b.reporter
-	buffer.pkg = path.Join(b.base, b.pkg)
+	buffer.pkg = path.Join(b.packages.BasePackage(), b.pkg)
 	buffer.file = filepath.Join(b.output, b.pkg, b.file+".go")
 	buffer.functions = make(map[string]interface{})
 	buffer.functions["lineComment"] = buffer.lineComment

--- a/pkg/golang/names.go
+++ b/pkg/golang/names.go
@@ -28,32 +28,23 @@ import (
 // create instances directly, use the NewNamesCalculator function instead.
 type NamesCalculatorBuilder struct {
 	reporter *reporter.Reporter
-	base     string
 }
 
 // NamesCalculator is an object used to calculate Go names. Don't create instances directly, use the
 // builder instead.
 type NamesCalculator struct {
 	reporter *reporter.Reporter
-	base     string
 }
 
 // NewNamesCalculator creates a Go names calculator builder.
 func NewNamesCalculator() *NamesCalculatorBuilder {
-	builder := new(NamesCalculatorBuilder)
-	return builder
+	return &NamesCalculatorBuilder{}
 }
 
 // Reporter sets the object that will be used to report information about the calculation processes,
 // including errors.
 func (b *NamesCalculatorBuilder) Reporter(value *reporter.Reporter) *NamesCalculatorBuilder {
 	b.reporter = value
-	return b
-}
-
-// Base sets the import path of the base package were the code will be generated.
-func (b *NamesCalculatorBuilder) Base(value string) *NamesCalculatorBuilder {
-	b.base = value
 	return b
 }
 
@@ -65,15 +56,11 @@ func (b *NamesCalculatorBuilder) Build() (calculator *NamesCalculator, err error
 		err = fmt.Errorf("reporter is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base package is mandatory")
-		return
-	}
 
 	// Create the calculator:
-	calculator = new(NamesCalculator)
-	calculator.reporter = b.reporter
-	calculator.base = b.base
+	calculator = &NamesCalculator{
+		reporter: b.reporter,
+	}
 
 	return
 }
@@ -108,23 +95,5 @@ func (c *NamesCalculator) Private(name *names.Name) string {
 
 // File converts the given name into an string, following the rules for Go source files.
 func (c *NamesCalculator) File(name *names.Name) string {
-	words := name.Words()
-	chunks := make([]string, len(words))
-	for i, word := range words {
-		chunks[i] = strings.ToLower(word.String())
-	}
-	file := strings.Join(chunks, "_")
-	return file
-}
-
-// Package converts the given name into an string, following the rules for Go package names.
-func (c *NamesCalculator) Package(name *names.Name) string {
-	words := name.Words()
-	chunks := make([]string, len(words))
-	for i, word := range words {
-		chunks[i] = strings.ToLower(word.String())
-	}
-	dir := strings.Join(chunks, "")
-	dir = AvoidReservedWord(dir)
-	return dir
+	return name.LowerJoined("_")
 }

--- a/pkg/golang/packages.go
+++ b/pkg/golang/packages.go
@@ -84,6 +84,16 @@ func (g *PackagesCalculator) ServicePackage(service *concepts.Service) string {
 	return service.Name().LowerJoined("")
 }
 
+// ServiceImport returns the complete import path of the package for the given service.
+func (g *PackagesCalculator) ServiceImport(service *concepts.Service) string {
+	return path.Join(g.base, g.ServicePackage(service))
+}
+
+// ServiceSelector returns the selector of the package for the given service.
+func (g *PackagesCalculator) ServiceSelector(service *concepts.Service) string {
+	return path.Base(g.ServicePackage(service))
+}
+
 // VersionPackage returns the name of the package for the given version.
 func (g *PackagesCalculator) VersionPackage(version *concepts.Version) string {
 	return path.Join(
@@ -92,12 +102,37 @@ func (g *PackagesCalculator) VersionPackage(version *concepts.Version) string {
 	)
 }
 
+// VersionImport returns the complete import path of the package for the given version.
+func (g *PackagesCalculator) VersionImport(version *concepts.Version) string {
+	return path.Join(g.base, g.VersionPackage(version))
+}
+
+// ServiceSelector returns the selector of the package for the given service.
+func (g *PackagesCalculator) VersionSelector(version *concepts.Version) string {
+	return path.Base(g.VersionPackage(version))
+}
+
 // HelpersPackage returns the name of the helpers package.
 func (g *PackagesCalculator) HelpersPackage() string {
 	return nomenclator.Helpers.LowerJoined("")
 }
 
+// HelpersImport returns complete import path of the helpers package.
+func (g *PackagesCalculator) HelpersImport() string {
+	return path.Join(g.base, g.HelpersPackage())
+}
+
 // ErrorsPackage returns the name of the errors package.
 func (g *PackagesCalculator) ErrorsPackage() string {
 	return nomenclator.Errors.LowerJoined("")
+}
+
+// ErrorsImport returns complete import path of the errors package.
+func (g *PackagesCalculator) ErrorsImport() string {
+	return path.Join(g.base, g.ErrorsPackage())
+}
+
+// BasePackage returns the import path of the base package.
+func (g *PackagesCalculator) BasePackage() string {
+	return g.base
 }

--- a/pkg/openapi/buffer.go
+++ b/pkg/openapi/buffer.go
@@ -34,7 +34,7 @@ import (
 type BufferBuilder struct {
 	reporter *reporter.Reporter
 	output   string
-	base     string
+	packages *golang.PackagesCalculator
 	pkg      string
 }
 
@@ -42,7 +42,7 @@ type BufferBuilder struct {
 type Buffer struct {
 	reporter *reporter.Reporter
 	output   string
-	base     string
+	packages *golang.PackagesCalculator
 	pkg      string
 	stream   *jsoniter.Stream
 	stack    []*int
@@ -65,9 +65,9 @@ func (b *BufferBuilder) Output(value string) *BufferBuilder {
 	return b
 }
 
-// Base sets the output base package.
-func (b *BufferBuilder) Base(value string) *BufferBuilder {
-	b.base = value
+// Packages sets the object that will be use to calculate package names.
+func (b *BufferBuilder) Packages(value *golang.PackagesCalculator) *BufferBuilder {
+	b.packages = value
 	return b
 }
 
@@ -89,8 +89,8 @@ func (b *BufferBuilder) Build() (buffer *Buffer, err error) {
 		err = fmt.Errorf("output directory is mandatory")
 		return
 	}
-	if b.base == "" {
-		err = fmt.Errorf("base package is mandatory")
+	if b.packages == nil {
+		err = fmt.Errorf("packages calculator is mandatory")
 		return
 	}
 	if b.pkg == "" {
@@ -111,7 +111,7 @@ func (b *BufferBuilder) Build() (buffer *Buffer, err error) {
 	buffer = &Buffer{
 		reporter: b.reporter,
 		output:   b.output,
-		base:     b.base,
+		packages: b.packages,
 		pkg:      b.pkg,
 		stream:   stream,
 		stack:    stack,
@@ -247,7 +247,7 @@ func (b *Buffer) Write() error {
 	goBuffer, err := golang.NewBufferBuilder().
 		Reporter(b.reporter).
 		Output(b.output).
-		Base(b.base).
+		Packages(b.packages).
 		Package(b.pkg).
 		File(filepath.Base(file)).
 		Build()


### PR DESCRIPTION
Currently the code generators receive as a parameter the base package
and also the packages calculator. To simplify that this patch moves the
base package to the packages calculator and remove it from all the
generators.