### PR TITLE
Make OpenAPI specification public

### DIFF
--- a/pkg/openapi/buffer.go
+++ b/pkg/openapi/buffer.go
@@ -255,8 +255,8 @@ func (b *Buffer) Write() error {
 		return err
 	}
 	goBuffer.Emit(`
-		// JSON document containing the OpenAPI specification:
-		var openAPI = []byte{
+		// OpenAPI contains the OpenAPI specification of the service in JSON.
+		var OpenAPI = []byte{
 			{{ byteArray .Data }}
 		}
 		`,


### PR DESCRIPTION
This patch changes renames the `openAPI` variable that contains the
_OpenAPI_ specification to `OpenAPI` so that it will be public.