### PR TITLE
Add version metadata support

### DIFF
--- a/pkg/generators/docs.go
+++ b/pkg/generators/docs.go
@@ -162,7 +162,7 @@ func (g *DocsGenerator) generateIndex() error {
 		Output(g.output).
 		File(fileName).
 		Function("displayName", g.displayName).
-		Function("fileName", g.fileName).
+		Function("resourceFile", g.fileName).
 		Build()
 	if err != nil {
 		return err
@@ -190,7 +190,7 @@ func (g *DocsGenerator) documentIndex() {
 		{{ range .Model.Services }}
 			{{ range .Versions }}
 				{{ range .Resources }}
-					link:{{ fileName . }}.html[{{ displayName . }}]
+					link:{{ resourceFile . }}.html[{{ displayName . }}]
 				{{ end }}
 			{{ end }}
 		{{ end }}
@@ -200,7 +200,7 @@ func (g *DocsGenerator) documentIndex() {
 		{{ range .Model.Services }}
 			{{ range .Versions }}
 				{{ range .Types }}
-					link:{{ fileName . }}.html[{{ displayName . }}]
+					link:{{ resourceFile . }}.html[{{ displayName . }}]
 				{{ end }}
 			{{ end }}
 		{{ end }}

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -69,8 +69,9 @@ var (
 	Long = names.ParseUsingCase("Long")
 
 	// M:
-	Map     = names.ParseUsingCase("Map")
-	Marshal = names.ParseUsingCase("Marshal")
+	Map      = names.ParseUsingCase("Map")
+	Marshal  = names.ParseUsingCase("Marshal")
+	Metadata = names.ParseUsingCase("Metadata")
 
 	// N:
 	New = names.ParseUsingCase("New")

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega/ghttp"
 
 	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
 )
 
 var _ = Describe("Client", func() {
@@ -107,5 +108,18 @@ var _ = Describe("Client", func() {
 		Expect(second).ToNot(BeNil())
 		Expect(second.Username()).To(Equal("youruser"))
 		Expect(second.Email()).To(Equal("yourmail"))
+	})
+
+	It("Can retrieve version metadata", func() {
+		server.AppendHandlers(RespondWith(http.StatusOK, `{
+			"server_version": "123"
+		}`))
+		client := cmv1.NewClient(transport, "", "")
+		response, err := client.Get().Send()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		body := response.Body()
+		Expect(body).ToNot(BeNil())
+		Expect(body.ServerVersion()).To(Equal("123"))
 	})
 })

--- a/tests/poll_test.go
+++ b/tests/poll_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Poll", func() {
 
 	It("Refuses to start without an interval", func() {
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			StartContext(ctx)
 		Expect(err).To(HaveOccurred())
@@ -62,7 +62,7 @@ var _ = Describe("Poll", func() {
 
 	It("Refuses to start without zero interval", func() {
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(0).
 			StartContext(ctx)
@@ -71,7 +71,7 @@ var _ = Describe("Poll", func() {
 
 	It("Refuses to start without negative interval", func() {
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 1 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(-1 * time.Millisecond).
 			StartContext(ctx)
@@ -86,7 +86,7 @@ var _ = Describe("Poll", func() {
 			"name": "mycluster"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			StartContext(ctx)
@@ -109,7 +109,7 @@ var _ = Describe("Poll", func() {
 			"reason": "Not found"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			Status(http.StatusNotFound).
@@ -139,7 +139,7 @@ var _ = Describe("Poll", func() {
 			"name": "mycluster"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			StartContext(ctx)
@@ -167,7 +167,7 @@ var _ = Describe("Poll", func() {
 			"name": "mycluster"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			StartContext(ctx)
@@ -193,7 +193,7 @@ var _ = Describe("Poll", func() {
 			}`),
 		)
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			StartContext(ctx)
@@ -211,10 +211,10 @@ var _ = Describe("Poll", func() {
 			"state": "ready"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			Predicate(func (response *cmv1.ClusterGetResponse) bool {
+			Predicate(func(response *cmv1.ClusterGetResponse) bool {
 				return response.Body().State() == cmv1.ClusterStateReady
 			}).
 			StartContext(ctx)
@@ -244,10 +244,10 @@ var _ = Describe("Poll", func() {
 			"state": "ready"
 		}`))
 		client := cmv1.NewClusterClient(transport, "", "")
-		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			Predicate(func (response *cmv1.ClusterGetResponse) bool {
+			Predicate(func(response *cmv1.ClusterGetResponse) bool {
 				return response.Body().State() == cmv1.ClusterStateReady
 			}).
 			StartContext(ctx)


### PR DESCRIPTION
This patch adds support for retrieving the metadata of a service
version. This is done via the root resource of that version which will
have a `Get` method that retrieves an object of type `Metadata`. For
example:

```
// Get the client for the root resource:
client := connection.ClustersMgmt().V1()

// Send the request to retrieve the metadata:
response, err := client.Get().Send()
if err != nil {
	...
}
metadata := response.Body()

// Print some metadata details:
fmt.Printf("server version: %s\n", metadata.ServerVersion())
```