### PR TITLE
Add simple conversion from AsciiDoc to Markdown

### DIFF
--- a/pkg/asciidoc/main_test.go
+++ b/pkg/asciidoc/main_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the definition of the test suite.
+
+package asciidoc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAsciiDoc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AsciiDoc")
+}

--- a/pkg/asciidoc/markdown.go
+++ b/pkg/asciidoc/markdown.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the code to convert from AsciiDoc to Markdown.
+
+package asciidoc
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Markdown converts the given text from AsciiDoc to Markdown.
+func Markdown(text string) string {
+	// Split the text into lines:
+	lines := strings.Split(text, "\n")
+
+	// Transform the lines:
+	lines = transformLines(lines, transformHeader)
+	lines = transformLines(lines, transformBlockHeader)
+	lines = transformLines(lines, transformBlockDelimiter)
+
+	// Join the lines and add line break at the end:
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func transformLines(lines []string, transformLine func(string) string) []string {
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		result[i] = transformLine(line)
+	}
+	return result
+}
+
+func transformHeader(line string) string {
+	if headerRE.MatchString(line) {
+		data := []byte(line)
+		for i := 0; data[i] == '='; i++ {
+			data[i] = '#'
+		}
+		line = string(data)
+	}
+	return line
+}
+
+func transformBlockHeader(line string) string {
+	if blockHeaderRE.MatchString(line) {
+		line = ""
+	}
+	return line
+}
+
+func transformBlockDelimiter(line string) string {
+	if blockDelimiterRE.MatchString(line) {
+		line = "```"
+	}
+	return line
+}
+
+var headerRE = regexp.MustCompile(`^=+[^=]*$`)
+var blockHeaderRE = regexp.MustCompile(`^\[\s*source\s*(,.*)\s*]\s*$`)
+var blockDelimiterRE = regexp.MustCompile(`^(\.\.\.\.|----)\s*$`)

--- a/pkg/asciidoc/markdown_test.go
+++ b/pkg/asciidoc/markdown_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the code to convert from AsciiDoc to Markdown.
+
+package asciidoc
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Conversion to Markdown", func() {
+	It("Converts files", func() {
+		// Get the list of AsciiDoc files in the `tests` directory:
+		adocFiles, err := filepath.Glob("tests/*.adoc")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(adocFiles)).ToNot(BeZero())
+
+		// Check that all the test files can be converted successfully:
+		for _, adocFile := range adocFiles {
+			mdFile := adocRE.ReplaceAllString(adocFile, ".md")
+			adocData, err := ioutil.ReadFile(adocFile)
+			Expect(err).ToNot(HaveOccurred())
+			adocText := string(adocData)
+			mdData, err := ioutil.ReadFile(mdFile)
+			Expect(err).ToNot(HaveOccurred())
+			mdText := string(mdData)
+			actualText := Markdown(adocText)
+			Expect(strings.TrimSpace(actualText)).To(Equal(strings.TrimSpace(mdText)))
+		}
+	})
+})
+
+// Regular expression used to replace the `.adoc` extension:
+var adocRE = regexp.MustCompile(`\.adoc$`)

--- a/pkg/asciidoc/tests/blocks.adoc
+++ b/pkg/asciidoc/tests/blocks.adoc
@@ -1,0 +1,19 @@
+....
+First line.
+Second line.
+....
+
+[source,go]
+----
+fmt.Printf("First line\n")
+fmt.Printf("Second line\n")
+----
+
+[source,json]
+----
+{
+  "first": "value",
+  "second": "value"
+}
+----
+

--- a/pkg/asciidoc/tests/blocks.md
+++ b/pkg/asciidoc/tests/blocks.md
@@ -1,0 +1,18 @@
+```
+First line.
+Second line.
+```
+
+
+```
+fmt.Printf("First line\n")
+fmt.Printf("Second line\n")
+```
+
+
+```
+{
+  "first": "value",
+  "second": "value"
+}
+```

--- a/pkg/asciidoc/tests/headers.adoc
+++ b/pkg/asciidoc/tests/headers.adoc
@@ -1,0 +1,3 @@
+= My header
+
+My text.

--- a/pkg/asciidoc/tests/headers.md
+++ b/pkg/asciidoc/tests/headers.md
@@ -1,0 +1,3 @@
+# My header
+
+My text.

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/openshift-online/ocm-api-metamodel/pkg/asciidoc"
 	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
 	"github.com/openshift-online/ocm-api-metamodel/pkg/golang"
 	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
@@ -586,6 +587,7 @@ func (g *OpenAPIGenerator) generateErrorSchema() {
 
 func (g *OpenAPIGenerator) generateDescription(doc string) {
 	if doc != "" {
+		doc = asciidoc.Markdown(doc)
 		g.buffer.Field("description", doc)
 	}
 }


### PR DESCRIPTION
This patch adds a versy simple (and limited) mechanism to convert
_AsciiDoc_ to _Markdown_. This is intended only for conversion of the
documents used in the generated _OpenAPI_ specification.