### PR TITLE
Support non-REST methods

### DIFF
--- a/pkg/http/binding.go
+++ b/pkg/http/binding.go
@@ -135,20 +135,20 @@ func (c *BindingCalculator) ResponseBodyParameters(method *concepts.Method) []*c
 func (c *BindingCalculator) Method(method *concepts.Method) string {
 	name := method.Name()
 	switch {
-	case name.Equals(nomenclator.Post):
-		return http.MethodPost
 	case name.Equals(nomenclator.Add):
 		return http.MethodPost
-	case name.Equals(nomenclator.List):
-		return http.MethodGet
-	case name.Equals(nomenclator.Get):
-		return http.MethodGet
-	case name.Equals(nomenclator.Update):
-		return http.MethodPatch
 	case name.Equals(nomenclator.Delete):
 		return http.MethodDelete
-	default:
+	case name.Equals(nomenclator.Get):
 		return http.MethodGet
+	case name.Equals(nomenclator.List):
+		return http.MethodGet
+	case name.Equals(nomenclator.Post):
+		return http.MethodPost
+	case name.Equals(nomenclator.Update):
+		return http.MethodPatch
+	default:
+		return http.MethodPost
 	}
 }
 
@@ -189,6 +189,27 @@ func (c *BindingCalculator) ServiceSegment(service *concepts.Service) string {
 // VersionSegment calculates the URL segment corresponding to the given version.
 func (c *BindingCalculator) VersionSegment(version *concepts.Version) string {
 	return version.Name().Snake()
+}
+
+// LocatorSegment calculates the URL segment corresponding to the given method.
+func (c *BindingCalculator) MethodSegment(method *concepts.Method) string {
+	name := method.Name()
+	switch {
+	case name.Equals(nomenclator.Add):
+		return ""
+	case name.Equals(nomenclator.Delete):
+		return ""
+	case name.Equals(nomenclator.Get):
+		return ""
+	case name.Equals(nomenclator.List):
+		return ""
+	case name.Equals(nomenclator.Post):
+		return ""
+	case name.Equals(nomenclator.Update):
+		return ""
+	default:
+		return name.Snake()
+	}
 }
 
 // LocatorSegment calculates the URL segment corresponding to the given locator.

--- a/tests/model/clusters_mgmt/v1/root_resource.model
+++ b/tests/model/clusters_mgmt/v1/root_resource.model
@@ -16,6 +16,14 @@ limitations under the License.
 
 // Root of the tree of resources of the clusters management service.
 resource Root {
+	method RegisterCluster {
+		in out Body Cluster
+	}
+
+	method RegisterDisconnected {
+		in out Body Cluster
+	}
+
 	// Reference to the resource that manages the collection of clusters.
 	locator Clusters {
 		target Clusters


### PR DESCRIPTION
This patch improves support for non-REST methods. For example, a method
declared like this:

```
method RegisterCluster {
	in out Body Cluster
}
```

Will be translated into an endpoint like this:

```
POST /api/clusters_mtmt/v1/register_cluster HTTP/1.1

{
  "id": 123,
  "name": "mycluster",
}
```

And will be called like this:

```
// Prepare the description of the cluster to register:
cluster, err := cmv1.NewCluster().
	ID("123").
	Name("mycluster").
	Build()
if err != nil {
	...
}

// Send the request to register the cluster:
response, err := connection.ClustersMgmt().V1().RegisterCluster().
	Body(cluster).
	SendContext(ctx).
if err != nil {
	...
}

// Print the result:
cluster = response.Body()
fmt.Printf("Registration date: %s\n", cluster.CreationTimestamp())
```