### PR TITLE
Add semantic checks

### DIFF
--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
 )
 
 // Method represents a method of a resource.
@@ -91,6 +92,26 @@ func (m *Method) GetParameter(name *names.Name) *Parameter {
 		}
 	}
 	return nil
+}
+
+// IsAction determined if this method is an action instead of a regular REST method.
+func (m *Method) IsAction() bool {
+	switch {
+	case m.name.Equals(nomenclator.Add):
+		return false
+	case m.name.Equals(nomenclator.Delete):
+		return false
+	case m.name.Equals(nomenclator.Get):
+		return false
+	case m.name.Equals(nomenclator.List):
+		return false
+	case m.name.Equals(nomenclator.Post):
+		return false
+	case m.name.Equals(nomenclator.Update):
+		return false
+	default:
+		return true
+	}
 }
 
 // MethodSlice is used to simplify sorting of slices of methods by name.

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -126,6 +126,11 @@ func (r *Resource) AddLocator(locator *Locator) {
 	}
 }
 
+// IsRoot returns `true` if this is the root of the tree of resources of the version.
+func (r *Resource) IsRoot() bool {
+	return r.owner != nil && r == r.owner.Root()
+}
+
 // ResourceSlice is used to simplify sorting of slices of resources by name.
 type ResourceSlice []*Resource
 

--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -1,0 +1,431 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the semantics checks.
+
+package language
+
+import (
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+)
+
+// checkMethod performs method level semantics checks.
+func (r *Reader) checkMethod(method *concepts.Method) {
+	name := method.Name()
+	switch {
+	case name.Equals(nomenclator.Add):
+		r.checkAdd(method)
+	case name.Equals(nomenclator.Delete):
+		r.checkDelete(method)
+	case name.Equals(nomenclator.Get):
+		r.checkGet(method)
+	case name.Equals(nomenclator.List):
+		r.checkList(method)
+	case name.Equals(nomenclator.Post):
+		r.checkPost(method)
+	case name.Equals(nomenclator.Update):
+		r.checkUpdate(method)
+	default:
+		r.checkAction(method)
+	}
+}
+
+func (r *Reader) checkAdd(method *concepts.Method) {
+	// Get the reference the resource:
+	resource := method.Owner()
+
+	// Only scalar and struct parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.Type().IsScalar() && !parameter.Type().IsStruct() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have parameters that are "+
+					"scalars or structs, but type of parameter '%s' is %s",
+				method, resource, parameter, parameter.Type().Kind(),
+			)
+		}
+	}
+
+	// Exactly one struct parameter:
+	var structs []*concepts.Parameter
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsStruct() {
+			structs = append(structs, parameter)
+		}
+	}
+	count := len(structs)
+	if count != 1 {
+		r.reporter.Errorf(
+			"Method '%s' of resource '%s' should have exactly one struct parameter "+
+				"but it has %d",
+			method, resource, count,
+		)
+	}
+
+	// Non scalar parameters should be input and output:
+	for _, parameter := range structs {
+		if !parameter.In() || !parameter.Out() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' should be 'in out'",
+				parameter, method, resource,
+			)
+		}
+	}
+
+	// Struct parameters should be named `body`:
+	for _, parameter := range structs {
+		if !nomenclator.Body.Equals(parameter.Name()) {
+			r.reporter.Errorf(
+				"Name of parameter '%s' of method '%s' of resource '%s' should "+
+					"be '%s'",
+				parameter, method, resource, nomenclator.Body,
+			)
+		}
+	}
+}
+
+func (r *Reader) checkDelete(method *concepts.Method) {
+	// Get the reference the resource:
+	resource := method.Owner()
+
+	// Only scalar parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.Type().IsScalar() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have scalar parameters, "+
+					"parameter '%s' is %s",
+				method, resource, parameter, parameter.Type().Kind(),
+			)
+		}
+	}
+
+	// Only input parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.In() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have 'in' parameters, but "+
+					"parameter '%s' isn't",
+				method, resource, parameter,
+			)
+		}
+		if parameter.Out() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have 'in' parameters, but "+
+					"parameter '%s' is 'out'",
+				method, resource, parameter,
+			)
+		}
+	}
+}
+
+func (r *Reader) checkGet(method *concepts.Method) {
+	// Get the reference to the resource:
+	resource := method.Owner()
+
+	// Only scalar and struct parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.Type().IsScalar() && !parameter.Type().IsStruct() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have parameters that are "+
+					"scalars or structs, but type of parameter '%s' is %s",
+				method, resource, parameter,
+				parameter.Type().Kind(),
+			)
+		}
+	}
+
+	// Exactly one struct parameter:
+	var structs []*concepts.Parameter
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsStruct() {
+			structs = append(structs, parameter)
+		}
+	}
+	count := len(structs)
+	if count != 1 {
+		r.reporter.Errorf(
+			"Method '%s' of resource '%s' should have exactly one struct parameter "+
+				"but it has %d",
+			method, resource, count,
+		)
+	}
+
+	// Scalar parameters should be input only:
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsScalar() {
+			if !parameter.In() {
+				r.reporter.Errorf(
+					"Scalar parameters of method '%s' of resource '%s' " +
+						"should be 'in' but parameter '%s' isn't",
+					method, resource, parameter,
+				)
+			}
+			if parameter.Out() {
+				r.reporter.Errorf(
+					"Scalar parameters of method '%s' of resource '%s" +
+						"should be 'in' but parameter '%s' is 'out'",
+					method, resource, parameter,
+				)
+			}
+		}
+	}
+
+	// Struct parameters should be output only:
+	for _, parameter := range structs {
+		if !parameter.Out() {
+			r.reporter.Errorf(
+				"Non scalar parameters of method '%s' of resource '%s' should "+
+					"be 'out' but parameter '%s' isn't",
+				method, resource, parameter,
+			)
+		}
+		if parameter.In() {
+			r.reporter.Errorf(
+				"Non scalar parameters of method '%s' of resource '%s' should "+
+					"be 'out' but parameter '%s' is 'in'",
+				method, resource, parameter,
+			)
+		}
+	}
+
+	// Struct parameters should be named `body`:
+	for _, parameter := range structs {
+		if !nomenclator.Body.Equals(parameter.Name()) {
+			r.reporter.Errorf(
+				"Name of parameter '%s' of method '%s' of resource '%s' should "+
+					"be '%s'",
+				parameter, method, resource,
+				nomenclator.Body,
+			)
+		}
+	}
+}
+
+func (r *Reader) checkList(method *concepts.Method) {
+	// Get the reference to the and to the version:
+	resource := method.Owner()
+	version := resource.Owner()
+
+	// Only scalar and list parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.Type().IsScalar() && !parameter.Type().IsList() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have parameters that are "+
+					"scalars or lists, but type of parameter '%s' is %s",
+				method, resource, parameter,
+				parameter.Type().Kind(),
+			)
+		}
+	}
+
+	// Exactly one list parameter:
+	var lists []*concepts.Parameter
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsList() {
+			lists = append(lists, parameter)
+		}
+	}
+	count := len(lists)
+	if count != 1 {
+		r.reporter.Errorf(
+			"Method '%s' of resource '%s' should have exactly one list parameter "+
+				"but it has %d",
+			method, resource, count,
+		)
+	}
+
+	// Check the `page` parameter:
+	page := method.GetParameter(nomenclator.Page)
+	if page == nil {
+		r.reporter.Warnf(
+			"Method '%s' of resource '%s' doesn't have a '%s' parameter",
+			method, resource, nomenclator.Page,
+		)
+	} else {
+		if page.Type() != version.Integer() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' doesn't have "+
+					"should be integer but it is %s",
+				page, method, resource, page.Type(),
+			)
+		}
+		if !page.In() || !page.Out() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' should be 'in out'",
+				page, method, resource,
+			)
+		}
+	}
+
+	// Check the `size` parameter:
+	size := method.GetParameter(nomenclator.Size)
+	if size == nil {
+		r.reporter.Warnf(
+			"Method '%s' of resource '%s' doesn't have a '%s' parameter",
+			method, resource, nomenclator.Size,
+		)
+	} else {
+		if size.Type() != version.Integer() {
+			r.reporter.Warnf(
+				"Parameter '%s' of method '%s' of resource '%s' doesn't have "+
+					"should be integer but it is %s",
+				size, method, resource, size.Type(),
+			)
+		}
+		if !size.In() || !size.Out() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' should be 'in out'",
+				size, method, resource,
+			)
+		}
+	}
+
+	// Check the `total` parameter:
+	total := method.GetParameter(nomenclator.Total)
+	if total == nil {
+		r.reporter.Warnf(
+			"Method '%s' of resource '%s' doesn't have a '%s' parameter",
+			method, resource, nomenclator.Total,
+		)
+	} else {
+		if total.Type() != version.Integer() {
+			r.reporter.Warnf(
+				"Parameter '%s' of method '%s' of resource '%s' doesn't have "+
+					"should be integer but it is %s",
+				total, method, resource, total.Type(),
+			)
+		}
+		if total.In() || !total.Out() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' should be 'out'",
+				total, method, resource,
+			)
+		}
+	}
+
+	// Check the `items` parameter:
+	items := method.GetParameter(nomenclator.Items)
+	if items == nil {
+		r.reporter.Errorf(
+			"Method '%s' of resource '%s' doesn't have a '%s' parameter",
+			method, resource, nomenclator.Items,
+		)
+	}
+
+	// List parameters should be output only:
+	for _, parameter := range lists {
+		if parameter.In() || !parameter.Out() {
+			r.reporter.Errorf(
+				"Parameters '%s' of method '%s' of resource '%s' should be 'out'",
+				parameter, method, resource.Name(),
+			)
+		}
+	}
+
+	// List parameters should be named `items`:
+	for _, parameter := range lists {
+		if !nomenclator.Items.Equals(parameter.Name()) {
+			r.reporter.Errorf(
+				"Name of parameter '%s' of method '%s' of resource '%s' should "+
+					"be '%s'",
+				parameter, method, resource, nomenclator.Items,
+			)
+		}
+	}
+}
+
+func (r *Reader) checkPost(method *concepts.Method) {
+	// Empty on purpose.
+}
+
+func (r *Reader) checkUpdate(method *concepts.Method) {
+	// Get the reference to the resource:
+	resource := method.Owner()
+
+	// Only scalar and struct parameters:
+	for _, parameter := range method.Parameters() {
+		if !parameter.Type().IsScalar() && !parameter.Type().IsStruct() {
+			r.reporter.Errorf(
+				"Method '%s' of resource '%s' can only have parameters that are "+
+					"scalars or structs, but type of parameter '%s' is %s",
+				method.Name(), resource.Name(), parameter.Name(),
+				parameter.Type().Kind,
+			)
+		}
+	}
+
+	// Exactly one struct parameter:
+	var structs []*concepts.Parameter
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsStruct() {
+			structs = append(structs, parameter)
+		}
+	}
+	count := len(structs)
+	if count != 1 {
+		r.reporter.Errorf(
+			"Method '%s' of resource '%s' should have exactly one struct parameter "+
+				"but it has %d",
+			method.Name(), resource.Name(), count,
+		)
+	}
+
+	// Scalar parameters should be input only:
+	for _, parameter := range method.Parameters() {
+		if parameter.Type().IsScalar() {
+			if !parameter.In() {
+				r.reporter.Errorf(
+					"Scalar parameters of method '%s' of resource '%s' " +
+						"should be 'in' but parameter '%s' isn't",
+					method.Name(), resource.Name(), parameter.Name(),
+				)
+			}
+			if parameter.Out() {
+				r.reporter.Errorf(
+					"Scalar parameters of method '%s' of resource '%s" +
+						"should be 'in' but parameter '%s' is 'out'",
+					method.Name(), resource.Name(), parameter.Name(),
+				)
+			}
+		}
+	}
+
+	// Struct parameters should be input and output:
+	for _, parameter := range structs {
+		if !parameter.In() || !parameter.Out() {
+			r.reporter.Errorf(
+				"Parameter '%s' of method '%s' of resource '%s' should be 'in out'",
+				parameter.Name(), method.Name(), resource.Name(),
+			)
+		}
+	}
+
+	// Struct parameters should be named `body`:
+	for _, parameter := range structs {
+		if !nomenclator.Body.Equals(parameter.Name()) {
+			r.reporter.Errorf(
+				"Name of parameter '%s' of method '%s' of resource '%s' should "+
+					"be '%s'",
+				parameter.Name(), method.Name(), resource.Name(),
+				nomenclator.Body,
+			)
+		}
+	}
+}
+
+func (r *Reader) checkAction(method *concepts.Method) {
+	// Empty on purpose.
+}

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -159,6 +159,17 @@ func (r *Reader) Read() (model *concepts.Model, err error) {
 		}
 	}
 
+	// Check methods:
+	for _, service := range r.model.Services() {
+		for _, version := range service.Versions() {
+			for _, resource := range version.Resources() {
+				for _, method := range resource.Methods() {
+					r.checkMethod(method)
+				}
+			}
+		}
+	}
+
 	// Check if there are errors:
 	errors := r.reporter.Errors()
 	if errors > 0 {

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -27,6 +27,7 @@ var (
 	Add     = names.ParseUsingCase("Add")
 
 	// B:
+	Body    = names.ParseUsingCase("Body")
 	Boolean = names.ParseUsingCase("Boolean")
 	Builder = names.ParseUsingCase("Builder")
 
@@ -59,6 +60,7 @@ var (
 	ID      = names.ParseUsingCase("ID")
 	Index   = names.ParseUsingCase("Index")
 	Integer = names.ParseUsingCase("Integer")
+	Items   = names.ParseUsingCase("Items")
 
 	// J:
 	Kind = names.ParseUsingCase("Kind")
@@ -90,18 +92,19 @@ var (
 	Resource = names.ParseUsingCase("Resource")
 	Response = names.ParseUsingCase("Response")
 	Root     = names.ParseUsingCase("Root")
-	Router   = names.ParseUsingCase("Router")
 
 	// S:
-	Service = names.ParseUsingCase("Service")
-	Set     = names.ParseUsingCase("Set")
-	Spec    = names.ParseUsingCase("Spec")
-	String  = names.ParseUsingCase("String")
 	Server  = names.ParseUsingCase("Server")
 	Servers = names.ParseUsingCase("Servers")
+	Service = names.ParseUsingCase("Service")
+	Set     = names.ParseUsingCase("Set")
+	Size    = names.ParseUsingCase("Size")
+	Spec    = names.ParseUsingCase("Spec")
+	String  = names.ParseUsingCase("String")
 
 	// T:
-	Type = names.ParseUsingCase("Type")
+	Total = names.ParseUsingCase("Total")
+	Type  = names.ParseUsingCase("Type")
 
 	// U:
 	Unmarshal = names.ParseUsingCase("Unmarshal")

--- a/tests/model/clusters_mgmt/v1/cluster_resource.model
+++ b/tests/model/clusters_mgmt/v1/cluster_resource.model
@@ -23,7 +23,7 @@ resource Cluster {
 
 	// Updates the cluster.
 	method Update {
-		in Body Cluster
+		in out Body Cluster
 	}
 
 	// Deletes the cluster.

--- a/tests/model/clusters_mgmt/v1/clusters_resource.model
+++ b/tests/model/clusters_mgmt/v1/clusters_resource.model
@@ -63,7 +63,7 @@ resource Clusters {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of clusters.
 		out Items []Cluster

--- a/tests/model/clusters_mgmt/v1/groups_resource.model
+++ b/tests/model/clusters_mgmt/v1/groups_resource.model
@@ -19,10 +19,10 @@ resource Groups {
 	// Retrieves the list of groups.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/tests/model/clusters_mgmt/v1/identity_providers_resource.model
+++ b/tests/model/clusters_mgmt/v1/identity_providers_resource.model
@@ -19,10 +19,10 @@ resource IdentityProviders {
 	// Retrieves the list of identity providers.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/tests/model/clusters_mgmt/v1/users_resource.model
+++ b/tests/model/clusters_mgmt/v1/users_resource.model
@@ -19,10 +19,10 @@ resource Users {
 	// Retrieves the list of users.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer


### PR DESCRIPTION
This patch adds some initial semantic checks. For example it adds a
check to verify that the `Total` parameter of the `List` methods is
`out` only.