### PR TITLE
Check default values of paging parameters

### DIFF
--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -251,6 +251,12 @@ func (r *Reader) checkList(method *concepts.Method) {
 				page,
 			)
 		}
+		if page.Default() != 1 {
+			r.reporter.Errorf(
+				"Default value of parameter `%s` should be 1",
+				page,
+			)
+		}
 	}
 
 	// Check the `size` parameter:
@@ -270,6 +276,12 @@ func (r *Reader) checkList(method *concepts.Method) {
 		if !size.In() || !size.Out() {
 			r.reporter.Errorf(
 				"Direction of parameter '%s' should be 'in out'",
+				size,
+			)
+		}
+		if size.Default() == nil {
+			r.reporter.Errorf(
+				"Parameter `%s` should have a default value",
 				size,
 			)
 		}

--- a/tests/model/clusters_mgmt/v1/groups_resource.model
+++ b/tests/model/clusters_mgmt/v1/groups_resource.model
@@ -19,10 +19,10 @@ resource Groups {
 	// Retrieves the list of groups.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		in out Page Integer
+		in out Page Integer = 1
 
 		// Number of items contained in the returned page.
-		in out Size Integer
+		in out Size Integer = 100
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/tests/model/clusters_mgmt/v1/identity_providers_resource.model
+++ b/tests/model/clusters_mgmt/v1/identity_providers_resource.model
@@ -19,10 +19,10 @@ resource IdentityProviders {
 	// Retrieves the list of identity providers.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		in out Page Integer
+		in out Page Integer = 1
 
 		// Number of items contained in the returned page.
-		in out Size Integer
+		in out Size Integer = 100
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/tests/model/clusters_mgmt/v1/users_resource.model
+++ b/tests/model/clusters_mgmt/v1/users_resource.model
@@ -19,10 +19,10 @@ resource Users {
 	// Retrieves the list of users.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		in out Page Integer
+		in out Page Integer = 1
 
 		// Number of items contained in the returned page.
-		in out Size Integer
+		in out Size Integer = 100
 
 		// Total number of items of the collection.
 		out Total Integer


### PR DESCRIPTION
This patch adds checks to ensure that the `Page` parameter has `1` as
the default value and that the `Size` parameter has a default value.