### PR TITLE
Fix marshal of errors

### DIFF
--- a/pkg/generators/errors.go
+++ b/pkg/generators/errors.go
@@ -349,20 +349,16 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 
 		// MarshalError writes an error to the given destination which can be an slice of bytes, a
 		// string, a reader or a JSON decoder.
-		func (e *Error) MarshalError(destination interface{}) error {
-			encoder, err := helpers.NewEncoder(destination)
+		func MarshalError(object *Error, target interface{}) error {
+			encoder, err := helpers.NewEncoder(target)
 			if err != nil {
 				return err
 			}
-			object, err := e.wrap()
+			data, err := object.wrap()
 			if err != nil {
 				return err
 			}
-			err = encoder.Encode(object)
-			if err != nil {
-				return err
-			}
-			return nil
+			return encoder.Encode(data)
 		}
 
 		// errorData is the data structure used internally to marshal and unmarshal errors.
@@ -381,13 +377,6 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 				return
 			}
 			object = new(Error)
-			if d.Kind != nil && *d.Kind != ErrorKind {
-				err = fmt.Errorf(
-					"expected kind '%s' but got '%s'",
-					ErrorKind, *d.Kind,
-				)
-				return
-			}
 			object.id = d.ID
 			object.href = d.HREF
 			object.code = d.Code
@@ -397,22 +386,17 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 
 		// wrap is the method used internally to convert the JSON unmarshalled data to an
 		// error.
-		func (d *Error) wrap() (object *errorData, err error) {
-			if d == nil {
+		func (e *Error) wrap() (data *errorData, err error) {
+			if e == nil {
 				return
 			}
-			object = new(errorData)
-			if d.Kind() != "" && d.Kind() != ErrorKind {
-				err = fmt.Errorf(
-					"expected kind '%s' but got '%s'",
-					ErrorKind, d.Kind(),
-				)
-				return
-			}
-			object.ID = d.id
-			object.HREF = d.href
-			object.Code = d.code
-			object.Reason = d.reason
+			data = new(errorData)
+			data.ID = e.id
+			data.HREF = e.href
+			data.Kind = new(string)
+			*data.Kind = ErrorKind
+			data.Code = e.code
+			data.Reason = e.reason
 			return
 		}
 
@@ -426,15 +410,15 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// SendError writes a given error and status code to a response writer.
 		// if an error occurred it will log the error and exit.
 		// This methods is used internaly and no backwards compatibily is guaranteed.
-		func SendError(w http.ResponseWriter, r *http.Request, error *Error) {
-			status, err := strconv.Atoi(error.ID())
+		func SendError(w http.ResponseWriter, r *http.Request, object *Error) {
+			status, err := strconv.Atoi(object.ID())
 			if err != nil {
 				SendPanic(w, r)
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)
-			err = error.MarshalError(w)
+			err = MarshalError(object, w)
 			if err != nil {
 				glog.Errorf("Can't send response body for request '%s'", r.URL.Path)
 				return
@@ -445,7 +429,7 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// This methods is used internaly and no backwards compatibily is guaranteed.
 		func SendPanic(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			err := panicError.MarshalError(w)
+			err := MarshalError(panicError, w)
 			if err != nil {
 				glog.Errorf(
 					"Can't send panic response for request '%s': %s",

--- a/tests/readers_test.go
+++ b/tests/readers_test.go
@@ -24,6 +24,7 @@ import (
 
 	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-api-metamodel/tests/api/errors"
 )
 
 var _ = Describe("Reader", func() {
@@ -410,5 +411,22 @@ var _ = Describe("Reader", func() {
 		Expect(second).ToNot(BeNil())
 		Expect(second.Username()).To(Equal("youruser"))
 		Expect(second.Email()).To(Equal("yourmail"))
+	})
+
+	It("Can read an error", func() {
+		object, err := errors.UnmarshalError(`{
+			"kind": "Error",
+			"id": "401",
+			"href": "/api/clusters_mgmt/v1/errors/401",
+			"code": "CLUSTERS-MGMT-401",
+			"reason": "My reason"
+		}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).ToNot(BeNil())
+		Expect(object.Kind()).To(Equal(errors.ErrorKind))
+		Expect(object.ID()).To(Equal("401"))
+		Expect(object.HREF()).To(Equal("/api/clusters_mgmt/v1/errors/401"))
+		Expect(object.Code()).To(Equal("CLUSTERS-MGMT-401"))
+		Expect(object.Reason()).To(Equal("My reason"))
 	})
 })

--- a/tests/writers_test.go
+++ b/tests/writers_test.go
@@ -26,6 +26,7 @@ import (
 
 	amv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/api/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-api-metamodel/tests/api/errors"
 )
 
 var _ = Describe("Writer", func() {
@@ -133,6 +134,26 @@ var _ = Describe("Writer", func() {
 					"email": "yourmail"
 				}
 			}
+		}`))
+	})
+
+	It("Can write an error", func() {
+		object, err := errors.NewError().
+			ID("401").
+			HREF("/api/clusters_mgmt/v1/errors/401").
+			Code("CLUSTERS-MGMT-401").
+			Reason("My reason").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		buffer := new(bytes.Buffer)
+		err = errors.MarshalError(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`{
+			"kind": "Error",
+			"id": "401",
+			"href": "/api/clusters_mgmt/v1/errors/401",
+			"code": "CLUSTERS-MGMT-401",
+			"reason": "My reason"
 		}`))
 	})
 })


### PR DESCRIPTION
Currently the code that converts errors to JSON doesn't write the `kind`
attribute. This patch fixes that.