### PR TITLE
Add list marshal and unmarshal tests

### DIFF
--- a/tests/marshal_test.go
+++ b/tests/marshal_test.go
@@ -20,6 +20,7 @@ package tests
 
 import (
 	"bytes"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -188,5 +189,191 @@ var _ = Describe("Marshal", func() {
 			"code": "CLUSTERS-MGMT-401",
 			"reason": "My reason"
 		}`))
+	})
+
+	It("Can write empty list of booleans", func() {
+		buffer := &bytes.Buffer{}
+		object := []bool{}
+		err := cmv1.MarshalBooleanList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[]`))
+	})
+
+	It("Can write list with false", func() {
+		buffer := &bytes.Buffer{}
+		object := []bool{false}
+		err := cmv1.MarshalBooleanList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[false]`))
+	})
+
+	It("Can write list with true", func() {
+		buffer := &bytes.Buffer{}
+		object := []bool{true}
+		err := cmv1.MarshalBooleanList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[true]`))
+	})
+
+	It("Can write list with multiple booleans", func() {
+		buffer := &bytes.Buffer{}
+		object := []bool{true, false}
+		err := cmv1.MarshalBooleanList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[true, false]`))
+	})
+
+	It("Can write list of integers", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{-1, 0, 1}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[-1, 0, 1]`))
+	})
+
+	It("Can write empty list of integers", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[]`))
+	})
+
+	It("Can write list with zero", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{0}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[0]`))
+	})
+
+	It("Can write list with positive integer", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{123}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[123]`))
+	})
+
+	It("Can write list with negative integer", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{-123}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[-123]`))
+	})
+
+	It("Can write list with multiple integers", func() {
+		buffer := &bytes.Buffer{}
+		object := []int{-123, 0, 123}
+		err := cmv1.MarshalIntegerList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[-123, 0, 123]`))
+	})
+
+	It("Can write empty list of floats", func() {
+		buffer := &bytes.Buffer{}
+		object := []float64{}
+		err := cmv1.MarshalFloatList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[]`))
+	})
+
+	It("Can write list with float zero", func() {
+		buffer := &bytes.Buffer{}
+		object := []float64{0.0}
+		err := cmv1.MarshalFloatList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[0.0]`))
+	})
+
+	It("Can write list with positive float", func() {
+		buffer := &bytes.Buffer{}
+		object := []float64{123.456}
+		err := cmv1.MarshalFloatList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[123.456]`))
+	})
+
+	It("Can write list with positive float", func() {
+		buffer := &bytes.Buffer{}
+		object := []float64{-123.456}
+		err := cmv1.MarshalFloatList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[-123.456]`))
+	})
+
+	It("Can write list with multiple floats", func() {
+		buffer := &bytes.Buffer{}
+		object := []float64{-123.456, 0, 123.456}
+		err := cmv1.MarshalFloatList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[-123.456, 0, 123.456]`))
+	})
+
+	It("Can write empty list of strings", func() {
+		buffer := &bytes.Buffer{}
+		object := []string{}
+		err := cmv1.MarshalStringList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[]`))
+	})
+
+	It("Can write list with empty string", func() {
+		buffer := &bytes.Buffer{}
+		object := []string{""}
+		err := cmv1.MarshalStringList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[""]`))
+	})
+
+	It("Can write list with one string", func() {
+		buffer := &bytes.Buffer{}
+		object := []string{"mystring"}
+		err := cmv1.MarshalStringList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`["mystring"]`))
+	})
+
+	It("Can write list with multiple strings", func() {
+		buffer := &bytes.Buffer{}
+		object := []string{"mystring", "yourstring"}
+		err := cmv1.MarshalStringList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`["mystring", "yourstring"]`))
+	})
+
+	It("Can write empty list of dates", func() {
+		buffer := &bytes.Buffer{}
+		object := []time.Time{}
+		err := cmv1.MarshalDateList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[]`))
+	})
+
+	It("Can write list with one date", func() {
+		buffer := &bytes.Buffer{}
+		object := []time.Time{
+			time.Date(2019, time.July, 14, 15, 16, 17, 0, time.UTC),
+		}
+		err := cmv1.MarshalDateList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[
+			"2019-07-14T15:16:17Z"
+		]`))
+	})
+
+	It("Can write list with multiple dates", func() {
+		buffer := &bytes.Buffer{}
+		object := []time.Time{
+			time.Date(2019, time.July, 14, 15, 16, 17, 0, time.UTC),
+			time.Date(2019, time.August, 15, 16, 17, 18, 0, time.UTC),
+		}
+		err := cmv1.MarshalDateList(object, buffer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(MatchJSON(`[
+			"2019-07-14T15:16:17Z",
+			"2019-08-15T16:17:18Z"
+		]`))
 	})
 })

--- a/tests/unmarshal_test.go
+++ b/tests/unmarshal_test.go
@@ -500,4 +500,140 @@ var _ = Describe("Unmarshal", func() {
 		Expect(object.ID()).To(Equal("123"))
 		Expect(object.Name()).To(Equal("mycluster"))
 	})
+
+	It("Can read empty list of booleans", func() {
+		object, err := cmv1.UnmarshalBooleanList(`[]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(BeEmpty())
+	})
+
+	It("Can read list with boolean true", func() {
+		object, err := cmv1.UnmarshalBooleanList(`[true]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]bool{true}))
+	})
+
+	It("Can read list with boolean false", func() {
+		object, err := cmv1.UnmarshalBooleanList(`[false]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]bool{false}))
+	})
+
+	It("Can read list with multiple booleans", func() {
+		object, err := cmv1.UnmarshalBooleanList(`[true, false]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]bool{true, false}))
+	})
+
+	It("Can read empty list of integers", func() {
+		object, err := cmv1.UnmarshalIntegerList(`[]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(BeEmpty())
+	})
+
+	It("Can read list with integer zero", func() {
+		object, err := cmv1.UnmarshalIntegerList(`[0]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]int{0}))
+	})
+
+	It("Can read list with positive integer", func() {
+		object, err := cmv1.UnmarshalIntegerList(`[123]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]int{123}))
+	})
+
+	It("Can read list with negative integer", func() {
+		object, err := cmv1.UnmarshalIntegerList(`[-123]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]int{-123}))
+	})
+
+	It("Can read list with multiple integers", func() {
+		object, err := cmv1.UnmarshalIntegerList(`[-123, 0, 123]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]int{-123, 0, 123}))
+	})
+
+	It("Can read empty list of floats", func() {
+		object, err := cmv1.UnmarshalFloatList(`[]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(BeEmpty())
+	})
+
+	It("Can read list with float zero", func() {
+		object, err := cmv1.UnmarshalFloatList(`[0.0]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]float64{0.0}))
+	})
+
+	It("Can read list with positive float", func() {
+		object, err := cmv1.UnmarshalFloatList(`[123.456]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]float64{123.456}))
+	})
+
+	It("Can read list with negative float", func() {
+		object, err := cmv1.UnmarshalFloatList(`[-123.456]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]float64{-123.456}))
+	})
+
+	It("Can read list with multiple floats", func() {
+		object, err := cmv1.UnmarshalFloatList(`[-123.456, 0, 123.456]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]float64{-123.456, 0.0, 123.456}))
+	})
+
+	It("Can read empty list of strings", func() {
+		object, err := cmv1.UnmarshalStringList(`[]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(BeEmpty())
+	})
+
+	It("Can read list with empty string", func() {
+		object, err := cmv1.UnmarshalStringList(`[""]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]string{""}))
+	})
+
+	It("Can read list with one string", func() {
+		object, err := cmv1.UnmarshalStringList(`["mystring"]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]string{"mystring"}))
+	})
+
+	It("Can read list with multiple strings", func() {
+		object, err := cmv1.UnmarshalStringList(`["mystring", "", "yourstring"]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]string{"mystring", "", "yourstring"}))
+	})
+
+	It("Can read empty list of dates", func() {
+		object, err := cmv1.UnmarshalDateList(`[]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(BeEmpty())
+	})
+
+	It("Can read list with one date", func() {
+		object, err := cmv1.UnmarshalDateList(`[
+			"2019-07-14T15:16:17Z"
+		]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]time.Time{
+			time.Date(2019, time.July, 14, 15, 16, 17, 0, time.UTC),
+		}))
+	})
+
+	It("Can read list with multiple dates", func() {
+		object, err := cmv1.UnmarshalDateList(`[
+			"2019-07-14T15:16:17Z",
+			"2019-08-15T16:17:18Z"
+		]`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object).To(Equal([]time.Time{
+			time.Date(2019, time.July, 14, 15, 16, 17, 0, time.UTC),
+			time.Date(2019, time.August, 15, 16, 17, 18, 0, time.UTC),
+		}))
+	})
 })


### PR DESCRIPTION
This patch adds tests that verify the marshal and unmarshal of lists of
scalar types.