### PR TITLE
Fix OpenAPI paths

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -671,7 +671,7 @@ func (g *OpenAPIGenerator) absolutePath(version *concepts.Version,
 		if locator.Variable() {
 			segments[i] = fmt.Sprintf("{%s_id}", g.binding.LocatorSegment(locator))
 		} else {
-			segments[i] = locator.Name().String()
+			segments[i] = g.binding.LocatorSegment(locator)
 		}
 	}
 	segments = append(prefix, segments...)


### PR DESCRIPTION
Currently path segments for locators without variables are generated
using the string representation of the name. That results in some names
containing acronyms in uppercase. For example:

```
"/api/clusters_mgmt/v1/clusters/{cluster_id}/metric_queries/socket_total_by_node_roles_OS": {
  ...
}

```

That last path segmet should be `socket_total_by_node_roles_os`.

This patch changes the OpenAPI generator so that it uses the right rules
to generate those path segments.