### PR TITLE
Release 0.0.22

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.22 Jan 9 2020
+
+- Fix generation of _OpenAPI_ paths so that all the characters are lower case.
+
 == 0.0.21 Jan 8 2020
 
 - Use JSON iterator instead of the default JSON Go package.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.21"
+const Version = "0.0.22"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix generation of _OpenAPI_ paths so that all the characters are lower case.