### PR TITLE
Fix generation of OpenAPI paths

### DIFF
--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -244,15 +244,18 @@ func (v *Version) Paths() [][]*Locator {
 		pending = pending[1:]
 
 		// Copy the path to the list of results:
-		result := make([]*Locator, len(current))
+		size := len(current)
+		result := make([]*Locator, size)
 		copy(result, current)
 		results = append(results, result)
 
 		// Check if the path can be extended, and if so extend it and add it to the list of
 		// pending paths:
-		last := current[len(current)-1]
+		last := current[size-1]
 		for _, locator := range last.Target().Locators() {
-			path := append(current, locator)
+			path := make([]*Locator, size+1)
+			copy(path, current)
+			path[size] = locator
 			pending = append(pending, path)
 		}
 	}


### PR DESCRIPTION
Currently the code that generates OpenAPI paths uses the `append`
function to extend the generated paths inside an iterative algorithm.
This results in some of the generated paths (which are slices of
pointers to objects) sharing the same underlying array. When the slice
is modified via any of those slides that share the underlying array the
generated path overwrites an existing one, resulting in duplicated and
missing paths. This patch addresses that issue replacing that use of
`append` with a combination of `make` and `copy`.