### PR TITLE
Add `Content-Type` to server responses

### DIFF
--- a/pkg/generators/golang/json_generator.go
+++ b/pkg/generators/golang/json_generator.go
@@ -1005,6 +1005,8 @@ func (g *JSONSupportGenerator) generateListMethodSource(method *concepts.Method)
 		}
 
 		func {{ writeResponseFunc .Method }}(response *{{ serverResponseName .Method }}, w http.ResponseWriter) error {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(response.status)
 			stream := helpers.NewStream(w)
 			stream.WriteObjectStart()
 			stream.WriteObjectField("kind")


### PR DESCRIPTION
This patch changes the generated code so that server responses contain
the required `Content-Type` header.