### PR TITLE
Avoid `gofmt -s` changes

### DIFF
--- a/pkg/generators/golang/json_generator.go
+++ b/pkg/generators/golang/json_generator.go
@@ -1500,7 +1500,7 @@ func (g *JSONSupportGenerator) generateWriteValue(value string, typ *concepts.Ty
 			stream.WriteObjectStart()
 			keys := make([]string, len({{ .Value }}))
 			i := 0;
-			for key, _ := range {{ .Value }} {
+			for key := range {{ .Value }} {
 				keys[i] = key
 				i++
 			}


### PR DESCRIPTION
This patch changes the Go code generator so that it avoid constructs
that the `govmt -s` command would simplify. Without this running `make
fmt` in the SDK project modifies generated code which is then rejected
by the tests that check that modified code ins't modified manually.