### PR TITLE
Update file header year to 2020

### DIFF
--- a/pkg/generators/golang/buffer.go
+++ b/pkg/generators/golang/buffer.go
@@ -466,7 +466,7 @@ func (b *Buffer) cleanPkg(name string) string {
 
 // Header that will be included in all generated files:
 const fileHeader = `/*
-Copyright (c) 2019 Red Hat, Inc.
+Copyright (c) 2020 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
It's time to update this file header copyright notice. This gives us 8 more months before we need to worry about it again :calendar: 