### PR TITLE
Release 0.0.27

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.27 Apr 7 2020
+
+- Update file header year to 2020
+
 == 0.0.26 Feb 26 2020
 
 - Add `operation_id` attribute to error objects and error messages.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.26"
+const Version = "0.0.27"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update file header year to 2020