### PR TITLE
OpenAPI: Fix expected response

### DIFF
--- a/pkg/http/binding_calculator.go
+++ b/pkg/http/binding_calculator.go
@@ -173,7 +173,7 @@ func (c *BindingCalculator) DefaultStatus(method *concepts.Method) string {
 	case name.Equals(nomenclator.Add):
 		status = http.StatusCreated
 	case name.Equals(nomenclator.Update):
-		status = http.StatusNoContent
+		status = http.StatusOK
 	case name.Equals(nomenclator.Delete):
 		status = http.StatusNoContent
 	}


### PR DESCRIPTION
When generating the OpenAPI specification, PATCH operations are set to
respond with 204: No Content, but the API Model expects the payload to
be sent. The Clusters Service also sends the payload on PATCH in most,
but not all, endpoints. This causes several issues:
* OpenAPI spec documentation shows a 204 response _with_ a response body
* Clusters Service has inconsistent responses for PATCH operations
* The SDK fails at unmarshaling the cluster response on update