### PR TITLE
Fix setter for Poll request params

### DIFF
--- a/pkg/generators/golang/clients_generator.go
+++ b/pkg/generators/golang/clients_generator.go
@@ -633,7 +633,7 @@ func (g *ClientsGenerator) generatePollMethodSource(resource *concepts.Resource,
 			//
 			{{ lineComment .Doc }}
 			func (r *{{ $requestName }}) {{ $setterName }}(value {{ $setterType }}) *{{ $requestName }} {
-				get.{{ $setterName }}(value)
+				r.request.{{ $setterName }}(value)
 				return r
 			}
 		{{ end }}


### PR DESCRIPTION
When generating Polling request clients with query parameters, the setter
needs to defer to the correct Get method to set values.