### PR TITLE
generator: Add interface type

### DIFF
--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -30,6 +30,7 @@ const (
 	UndefinedType TypeKind = iota
 	ClassType
 	EnumType
+	InterfaceType
 	ListType
 	MapType
 	ScalarType
@@ -43,6 +44,8 @@ func (k TypeKind) String() string {
 		return "class"
 	case EnumType:
 		return "enum"
+	case InterfaceType:
+		return "interface{}"
 	case ListType:
 		return "list"
 	case MapType:
@@ -145,6 +148,11 @@ func (t *Type) IsEnum() bool {
 	return t.kind == EnumType
 }
 
+// IsInterface returns true iff this type is an interface{} type.
+func (t *Type) IsInterface() bool {
+	return t.kind == InterfaceType
+}
+
 // IsList returns true iff this type is a list type.
 func (t *Type) IsList() bool {
 	return t.kind == ListType
@@ -155,9 +163,10 @@ func (t *Type) IsMap() bool {
 	return t.kind == MapType
 }
 
-// IsScalar returns true iff this type is an scalar type.
+// IsScalar returns true iff this type is an scalar type. Note that interface types are also considered
+// scalar types due to their opaque nature in the SDK.
 func (t *Type) IsScalar() bool {
-	return t.kind == ScalarType || t.kind == EnumType
+	return t.kind == ScalarType || t.kind == EnumType || t.kind == InterfaceType
 }
 
 // IsStruct returns true iff this type is an struct type. Note that class types are also considered

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -57,6 +57,12 @@ func NewVersion() *Version {
 	version.addScalarType(nomenclator.String)
 	version.addScalarType(nomenclator.Date)
 
+	// Add the built-in interface{} type:
+	// We treat the built-in interface type as scalar for most purposes,
+	// but define it as a new type to differentiate in how pointers are
+	// generated.
+	version.addInterfaceType(nomenclator.Interface)
+
 	return version
 }
 
@@ -144,6 +150,11 @@ func (v *Version) FloatType() *Type {
 // DateType returns the date type.
 func (v *Version) DateType() *Type {
 	return v.FindType(nomenclator.Date)
+}
+
+// InterfaceType returns the interface{} type.
+func (v *Version) InterfaceType() *Type {
+	return v.FindType(nomenclator.Interface)
 }
 
 // Resources returns the list of resources that are part of this version.
@@ -275,6 +286,21 @@ func (v *Version) addScalarType(name *names.Name) {
 	listType.SetKind(ListType)
 	listType.SetName(names.Cat(name, nomenclator.List))
 	listType.SetElement(scalarType)
+	v.AddType(listType)
+}
+
+func (v *Version) addInterfaceType(name *names.Name) {
+	// Add the interface{} type:
+	interfaceType := NewType()
+	interfaceType.SetKind(InterfaceType)
+	interfaceType.SetName(name)
+	v.AddType(interfaceType)
+
+	// Add the list type:
+	listType := NewType()
+	listType.SetKind(ListType)
+	listType.SetName(names.Cat(name, nomenclator.List))
+	listType.SetElement(interfaceType)
 	v.AddType(listType)
 }
 

--- a/pkg/generators/golang/types_calculator.go
+++ b/pkg/generators/golang/types_calculator.go
@@ -173,6 +173,10 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 		ref = &TypeReference{}
 		ref.name = "string"
 		ref.text = "string"
+	case typ == version.InterfaceType():
+		ref = &TypeReference{}
+		ref.name = "interface{}"
+		ref.text = "interface{}"
 	case typ == version.DateType():
 		ref = &TypeReference{}
 		ref.imprt = "time"
@@ -224,7 +228,7 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 // the nil value.
 func (c *TypesCalculator) NullableReference(typ *concepts.Type) *TypeReference {
 	switch {
-	case typ.IsScalar() || typ.IsStruct():
+	case (typ.IsScalar() && !typ.IsInterface()) || typ.IsStruct():
 		ref := c.ValueReference(typ)
 		ref.text = fmt.Sprintf("*%s", ref.text)
 		return ref
@@ -347,7 +351,7 @@ func (c *TypesCalculator) BuilderReference(typ *concepts.Type) *TypeReference {
 func (c *TypesCalculator) ZeroValue(typ *concepts.Type) string {
 	version := typ.Owner()
 	switch {
-	case typ.IsStruct() || typ.IsList() || typ.IsMap():
+	case typ.IsStruct() || typ.IsList() || typ.IsMap() || typ.IsInterface():
 		return `nil`
 	case typ.IsEnum():
 		ref := c.ValueReference(typ)
@@ -385,6 +389,8 @@ func (c *TypesCalculator) Package(typ *concepts.Type) (imprt, selector string) {
 	case typ == version.FloatType():
 		return
 	case typ == version.StringType():
+		return
+	case typ == version.InterfaceType():
 		return
 	case typ == version.DateType():
 		imprt = "time"

--- a/pkg/generators/golang/types_generator.go
+++ b/pkg/generators/golang/types_generator.go
@@ -411,7 +411,7 @@ func (g *TypesGenerator) generateStructTypeSource(typ *concepts.Type) {
 			//
 			{{ lineComment .Doc }}
 			func (o *{{ $objectName }}) {{ $getterName }}() {{ $getterType }} {
-				{{ if or .Type.IsStruct .Type.IsList .Type.IsMap }}
+				{{ if or .Type.IsStruct .Type.IsList .Type.IsMap .Type.IsInterface }}
 					if o == nil {
 						return nil
 					}
@@ -431,7 +431,7 @@ func (g *TypesGenerator) generateStructTypeSource(typ *concepts.Type) {
 			func (o *{{ $objectName }}) Get{{ $getterName }}() (value {{ $getterType }}, ok bool) {
 				ok = o != nil && o.{{ $fieldName }} != nil
 				if ok {
-					{{ if or .Type.IsStruct .Type.IsList .Type.IsMap }}
+					{{ if or .Type.IsStruct .Type.IsList .Type.IsMap .Type.IsInterface }}
 						value = o.{{ $fieldName }}
 					{{ else }}
 						value = *o.{{ $fieldName }}

--- a/pkg/generators/openapi/openapi_generator.go
+++ b/pkg/generators/openapi/openapi_generator.go
@@ -564,6 +564,8 @@ func (g *OpenAPIGenerator) generateSchemaReference(typ *concepts.Type) {
 	case typ == version.DateType():
 		g.buffer.Field("type", "string")
 		g.buffer.Field("format", "date-time")
+	case typ == version.InterfaceType():
+		g.buffer.Field("type", "object")
 	case typ.IsEnum() || typ.IsStruct():
 		g.buffer.Field("$ref", "#/components/schemas/"+g.names.SchemaName(typ))
 	case typ.IsList():

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -57,10 +57,11 @@ var (
 	Helpers = names.ParseUsingCase("Helpers")
 
 	// I:
-	ID      = names.ParseUsingCase("ID")
-	Index   = names.ParseUsingCase("Index")
-	Integer = names.ParseUsingCase("Integer")
-	Items   = names.ParseUsingCase("Items")
+	ID        = names.ParseUsingCase("ID")
+	Index     = names.ParseUsingCase("Index")
+	Integer   = names.ParseUsingCase("Integer")
+	Interface = names.ParseUsingCase("Interface")
+	Items     = names.ParseUsingCase("Items")
 
 	// J:
 	JSON = names.ParseUsingCase("JSON")


### PR DESCRIPTION
There are instances where we need the SDK to allow attributes of type
interface{} in the API. In this case we can treat the value as
a nullable scalar type and generate it without the pointer indirection.