### PR TITLE
names: Support numeric initialisms

### DIFF
--- a/pkg/names/case.go
+++ b/pkg/names/case.go
@@ -32,10 +32,10 @@ func isLower(s string) bool {
 	return true
 }
 
-// isUpper checks if all the runes of the given string are upper case.
+// isUpper checks if all the runes of the given string are upper case or digits.
 func isUpper(s string) bool {
 	for _, r := range s {
-		if !unicode.IsUpper(r) {
+		if !unicode.IsUpper(r) && !unicode.IsDigit(r) {
 			return false
 		}
 	}

--- a/pkg/names/parser_test.go
+++ b/pkg/names/parser_test.go
@@ -50,5 +50,6 @@ var _ = Describe("Parser", func() {
 		Entry("Three chars initialism plural", "CPUs", "CPUs"),
 		Entry("Three chars initialism plural after word", "ClusterCPUs", "cluster_CPUs"),
 		Entry("Three chars initialism plural before word", "CPUsList", "CPUs_list"),
+		Entry("Words with numbers", "ClientX509CertURL", "client_X509_cert_URL"),
 	)
 })


### PR DESCRIPTION
When determining field names with digits, we should treat them as part
of an initialism. Otherwise numeric values end up as part of their own
word part and generate repeating components in field names.