### PR TITLE
Add presence bitmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift-online/ocm-api-metamodel
 go 1.15
 
 require (
-	github.com/antlr/antlr4 v0.0.0-20210126174035-365a56f10f86
+	github.com/antlr/antlr4 v0.0.0-20210127121638-62a0b02bf460
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/json-iterator/go v1.1.10
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/antlr/antlr4 v0.0.0-20210126174035-365a56f10f86 h1:EZS/bVJ6AP6dgr8nJUxzPS+ImRaXFQZsfacDmFhe7TI=
-github.com/antlr/antlr4 v0.0.0-20210126174035-365a56f10f86/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4 v0.0.0-20210127121638-62a0b02bf460 h1:H+x7i3T3L4a3Maec+dtXdGVznFa6qgyXsYVthKB+rk4=
+github.com/antlr/antlr4 v0.0.0-20210127121638-62a0b02bf460/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -34,7 +34,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -71,7 +70,6 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -106,7 +104,6 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -119,10 +116,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -159,7 +154,6 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -194,7 +188,6 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -333,7 +326,6 @@ google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyz
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/generators/golang/errors_generator.go
+++ b/pkg/generators/golang/errors_generator.go
@@ -187,20 +187,22 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 
 		// ErrorBuilder is a builder for the error type.
 		type ErrorBuilder struct{
-			id          *string
-			href        *string
-			code        *string
-			reason      *string
-			operationID *string
+			bitmap_     uint32
+			id          string
+			href        string
+			code        string
+			reason      string
+			operationID string
 		}
 
 		// Error represents errors.
 		type Error struct {
-			id          *string
-			href        *string
-			code        *string
-			reason      *string
-			operationID *string
+			bitmap_     uint32
+			id          string
+			href        string
+			code        string
+			reason      string
+			operationID string
 		}
 
 		// NewError creates a new builder that can then be used to create error objects.
@@ -210,31 +212,36 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 
 		// ID sets the identifier of the error.
 		func (b *ErrorBuilder) ID(value string) *ErrorBuilder {
-			b.id = &value
+			b.id = value
+			b.bitmap_ |= 1
 			return b
 		}
 
 		// HREF sets the link of the error.
 		func (b *ErrorBuilder) HREF(value string) *ErrorBuilder {
-			b.href = &value
+			b.href = value
+			b.bitmap_ |= 2
 			return b
 		}
 
 		// Code sets the code of the error.
 		func (b *ErrorBuilder) Code(value string) *ErrorBuilder {
-			b.code = &value
+			b.code = value
+			b.bitmap_ |= 4
 			return b
 		}
 
 		// Reason sets the reason of the error.
 		func (b *ErrorBuilder) Reason(value string) *ErrorBuilder {
-			b.reason = &value
+			b.reason = value
+			b.bitmap_ |= 8
 			return b
 		}
 
 		// OperationID sets the identifier of the operation that caused the error.
 		func (b *ErrorBuilder) OperationID(value string) *ErrorBuilder {
-			b.operationID = &value
+			b.operationID = value
+			b.bitmap_ |= 16
 			return b
 		}
 
@@ -246,6 +253,7 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 				code:        b.code,
 				reason:      b.reason,
 				operationID: b.operationID,
+				bitmap_:   b.bitmap_,
 			}
 			return
 		}
@@ -260,8 +268,8 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 
 		// ID returns the identifier of the error.
 		func (e *Error) ID() string {
-			if e != nil && e.id != nil {
-				return *e.id
+			if e != nil && e.bitmap_&1 != 0 {
+				return e.id
 			}
 			return ""
 		}
@@ -269,17 +277,17 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// GetID returns the identifier of the error and a flag indicating if the
 		// identifier has a value.
 		func (e *Error) GetID() (value string, ok bool) {
-			ok = e != nil && e.id != nil
+			ok = e != nil && e.bitmap_&1 != 0
 			if ok {
-				value = *e.id
+				value = e.id
 			}
 			return
 		}
 
 		// HREF returns the link to the error.
 		func (e *Error) HREF() string {
-			if e != nil && e.href != nil {
-				return *e.href
+			if e != nil && e.bitmap_&2 != 0 {
+				return e.href
 			}
 			return ""
 		}
@@ -287,17 +295,17 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// GetHREF returns the link of the error and a flag indicating if the
 		// link has a value.
 		func (e *Error) GetHREF() (value string, ok bool) {
-			ok = e != nil && e.href != nil
+			ok = e != nil && e.bitmap_&2 != 0
 			if ok {
-				value = *e.href
+				value = e.href
 			}
 			return
 		}
 
 		// Code returns the code of the error.
 		func (e *Error) Code() string {
-			if e != nil && e.code != nil {
-				return *e.code
+			if e != nil && e.bitmap_&4 != 0 {
+				return e.code
 			}
 			return ""
 		}
@@ -305,17 +313,17 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// GetCode returns the link of the error and a flag indicating if the
 		// code has a value.
 		func (e *Error) GetCode() (value string, ok bool) {
-			ok = e != nil && e.code != nil
+			ok = e != nil && e.bitmap_&4 != 0
 			if ok {
-				value = *e.code
+				value = e.code
 			}
 			return
 		}
 
 		// Reason returns the reason of the error.
 		func (e *Error) Reason() string {
-			if e != nil && e.reason != nil {
-				return *e.reason
+			if e != nil && e.bitmap_&8 != 0 {
+				return e.reason
 			}
 			return ""
 		}
@@ -323,17 +331,17 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// GetReason returns the link of the error and a flag indicating if the
 		// reason has a value.
 		func (e *Error) GetReason() (value string, ok bool) {
-			ok = e != nil && e.reason != nil
+			ok = e != nil && e.bitmap_&8 != 0
 			if ok {
-				value = *e.reason
+				value = e.reason
 			}
 			return
 		}
 
 		// OperationID returns the identifier of the operation that caused the error.
 		func (e *Error) OperationID() string {
-			if e != nil && e.operationID != nil {
-				return *e.operationID
+			if e != nil && e.bitmap_&16 != 0 {
+				return e.operationID
 			}
 			return ""
 		}
@@ -341,9 +349,9 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// GetOperationID returns the identifier of the operation that caused the error and
 		// a flag indicating if that identifier does have a value.
 		func (e *Error) GetOperationID() (value string, ok bool) {
-			ok = e != nil && e.operationID != nil
+			ok = e != nil && e.bitmap_&16 != 0
 			if ok {
-				value = *e.operationID
+				value = e.operationID
 			}
 			return
 		}
@@ -351,14 +359,14 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 		// Error is the implementation of the error interface.
 		func (e *Error) Error() string {
 			chunks := make([]string, 0, 3)
-			if e.id != nil && *e.id != "" {
-				chunks = append(chunks, fmt.Sprintf("identifier is '%s'", *e.id))
+			if e.id != "" {
+				chunks = append(chunks, fmt.Sprintf("identifier is '%s'", e.id))
 			}
-			if e.code != nil && *e.code != "" {
-				chunks = append(chunks, fmt.Sprintf("code is '%s'", *e.code))
+			if e.code != "" {
+				chunks = append(chunks, fmt.Sprintf("code is '%s'", e.code))
 			}
-			if e.operationID != nil && *e.operationID != "" {
-				chunks = append(chunks, fmt.Sprintf("operation identifier is '%s'", *e.operationID))
+			if e.operationID != "" {
+				chunks = append(chunks, fmt.Sprintf("operation identifier is '%s'", e.operationID))
 			}
 			var result string
 			size := len(chunks)
@@ -367,11 +375,11 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 			} else if size > 1 {
 				result = strings.Join(chunks[0:size-1], ", ") + " and " + chunks[size-1]
 			}
-			if e.reason != nil && *e.reason != "" {
+			if e.reason != "" {
 				if result != "" {
 					result = result + ": "
 				}
-				result = result + *e.reason
+				result = result + e.reason
 			}
 			if result == "" {
 				result = "unknown error"
@@ -405,20 +413,20 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 				}
 				switch field {
 				case "id":
-					value := iterator.ReadString()
-					object.id = &value
+					object.id = iterator.ReadString()
+					object.bitmap_ |= 1
 				case "href":
-					value := iterator.ReadString()
-					object.href = &value
+					object.href = iterator.ReadString()
+					object.bitmap_ |= 2
 				case "code":
-					value := iterator.ReadString()
-					object.code = &value
+					object.code = iterator.ReadString()
+					object.bitmap_ |= 4
 				case "reason":
-					value := iterator.ReadString()
-					object.reason = &value
+					object.reason = iterator.ReadString()
+					object.bitmap_ |= 8
 				case "operation_id":
-					value := iterator.ReadString()
-					object.operationID = &value
+					object.operationID = iterator.ReadString()
+					object.bitmap_ |= 16
 				default:
 					iterator.ReadAny()
 				}
@@ -438,30 +446,30 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 			stream.WriteObjectStart()
 			stream.WriteObjectField("kind")
 			stream.WriteString(ErrorKind)
-			if e.id != nil {
+			if e.bitmap_&1 != 0 {
 				stream.WriteMore()
 				stream.WriteObjectField("id")
-				stream.WriteString(*e.id)
+				stream.WriteString(e.id)
 			}
-			if e.href != nil {
+			if e.bitmap_&2 != 0 {
 				stream.WriteMore()
 				stream.WriteObjectField("href")
-				stream.WriteString(*e.href)
+				stream.WriteString(e.href)
 			}
-			if e.code != nil {
+			if e.bitmap_&4 != 0 {
 				stream.WriteMore()
 				stream.WriteObjectField("code")
-				stream.WriteString(*e.code)
+				stream.WriteString(e.code)
 			}
-			if e.reason != nil {
+			if e.bitmap_&8 != 0 {
 				stream.WriteMore()
 				stream.WriteObjectField("reason")
-				stream.WriteString(*e.reason)
+				stream.WriteString(e.reason)
 			}
-			if e.operationID != nil {
+			if e.bitmap_&16 != 0 {
 				stream.WriteMore()
 				stream.WriteObjectField("operation_id")
-				stream.WriteString(*e.operationID)
+				stream.WriteString(e.operationID)
 			}
 			stream.WriteObjectEnd()
 		}

--- a/tests/go/types_test.go
+++ b/tests/go/types_test.go
@@ -237,12 +237,12 @@ var _ = Describe("Type", func() {
 			Expect(list.Empty()).To(BeFalse())
 		})
 
-		It("Returns `true` for empty map of strings", func() {
+		It("Returns `false` for empty map of strings", func() {
 			list, err := cmv1.NewCluster().
 				Properties(map[string]string{}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(list.Empty()).To(BeTrue())
+			Expect(list.Empty()).To(BeFalse())
 		})
 
 		It("Returns `false` for map of strings with one value", func() {
@@ -266,12 +266,12 @@ var _ = Describe("Type", func() {
 			Expect(list.Empty()).To(BeFalse())
 		})
 
-		It("Returns `true` for empty map of objects", func() {
+		It("Returns `false` for empty map of objects", func() {
 			list, err := amv1.NewRegistryAuths().
 				Map(map[string]*amv1.RegistryAuthBuilder{}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(list.Empty()).To(BeTrue())
+			Expect(list.Empty()).To(BeFalse())
 		})
 
 		It("Returns `false` for map of objects with one value", func() {
@@ -293,6 +293,14 @@ var _ = Describe("Type", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `true` empty link", func() {
+			object, err := cmv1.NewCluster().
+				Link(true).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object.Empty()).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
This patch changes the generated code so that instead of using pointers to
store attributes of scalar values (strings, integers, etc) it stores them
directly and uses a bitmap to keep track of which attributes are present. This
reduces the use of CPU and the number of allocations. In a test that loads 1
million clusters in memory it reduces CPU by approx 20% and memory by approx
10%.