### PR TITLE
Add `documentedSupport` and `namedSupport`

### DIFF
--- a/pkg/concepts/attribute.go
+++ b/pkg/concepts/attribute.go
@@ -22,9 +22,10 @@ import (
 
 // Attribute is the representation of an attribute of an structured type.
 type Attribute struct {
+	documentedSupport
+	namedSupport
+
 	owner *Type
-	doc   string
-	name  *names.Name
 	link  bool
 	typ   *Type
 }
@@ -42,26 +43,6 @@ func (a *Attribute) Owner() *Type {
 // SetOwner sets the type that owns this attribute.
 func (a *Attribute) SetOwner(value *Type) {
 	a.owner = value
-}
-
-// Doc returns the documentation of this attribute.
-func (a *Attribute) Doc() string {
-	return a.doc
-}
-
-// SetDoc sets the documentation of this attribute.
-func (a *Attribute) SetDoc(value string) {
-	a.doc = value
-}
-
-// Name returns the name of the attribute.
-func (a *Attribute) Name() *names.Name {
-	return a.name
-}
-
-// SetName sets the name of the attribute.
-func (a *Attribute) SetName(value *names.Name) {
-	a.name = value
 }
 
 // Link returns true if the attribute is a link, false otherwise.

--- a/pkg/concepts/error.go
+++ b/pkg/concepts/error.go
@@ -22,8 +22,10 @@ import (
 
 // Error is the representation of a catagery of errors.
 type Error struct {
+	documentedSupport
+	namedSupport
+
 	owner *Version
-	doc   string
 	name  *names.Name
 	code  int
 }
@@ -41,26 +43,6 @@ func (e *Error) Owner() *Version {
 // SetOwner sets the version that owns this error.
 func (e *Error) SetOwner(version *Version) {
 	e.owner = version
-}
-
-// Doc returns the documentation of this error.
-func (e *Error) Doc() string {
-	return e.doc
-}
-
-// SetDoc sets the documentation of this error.
-func (e *Error) SetDoc(value string) {
-	e.doc = value
-}
-
-// Name returns the name of this error.
-func (e *Error) Name() *names.Name {
-	return e.name
-}
-
-// SetName sets the name of this error.
-func (e *Error) SetName(value *names.Name) {
-	e.name = value
 }
 
 // Code returns the numeric code of this error.

--- a/pkg/concepts/locator.go
+++ b/pkg/concepts/locator.go
@@ -22,9 +22,10 @@ import (
 
 // Locator represents a resource locator, the reference from a resource to another resource.
 type Locator struct {
+	documentedSupport
+	namedSupport
+
 	owner    *Resource
-	doc      string
-	name     *names.Name
 	variable bool
 	target   *Resource
 }
@@ -44,26 +45,6 @@ func (l *Locator) SetOwner(value *Resource) {
 	l.owner = value
 }
 
-// Doc returns the documentation of this locator.
-func (l *Locator) Doc() string {
-	return l.doc
-}
-
-// SetDoc sets the documentation of this locator.
-func (l *Locator) SetDoc(value string) {
-	l.doc = value
-}
-
-// Name returns the name of the locator.
-func (l *Locator) Name() *names.Name {
-	return l.name
-}
-
-// SetName sets the name of the locator.
-func (l *Locator) SetName(value *names.Name) {
-	l.name = value
-}
-
 // Variable returns the flag that indicates if the name of the referenced resource is a variable
 // instead of a fixed URL segment. For example, in the reference from the clusters resource to the
 // cluster resource the name is a variable, which contains the identifier of the cluster.
@@ -71,7 +52,7 @@ func (l *Locator) Variable() bool {
 	return l.variable
 }
 
-// Variable sets the flag that indicates if the name of the referenced resource is a variable
+// SetVariable sets the flag that indicates if the name of the referenced resource is a variable
 // instead of a fixed URL segment.
 func (l *Locator) SetVariable(value bool) {
 	l.variable = true

--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -25,9 +25,10 @@ import (
 
 // Method represents a method of a resource.
 type Method struct {
+	documentedSupport
+	namedSupport
+
 	owner      *Resource
-	doc        string
-	name       *names.Name
 	parameters ParameterSlice
 }
 
@@ -46,26 +47,6 @@ func (m *Method) SetOwner(value *Resource) {
 	m.owner = value
 }
 
-// Doc returns the documentation of this method.
-func (m *Method) Doc() string {
-	return m.doc
-}
-
-// SetDoc sets the documentation of this type.
-func (m *Method) SetDoc(value string) {
-	m.doc = value
-}
-
-// Name returns the name of the method.
-func (m *Method) Name() *names.Name {
-	return m.name
-}
-
-// SetName sets the name of the method.
-func (m *Method) SetName(value *names.Name) {
-	m.name = value
-}
-
 // Parameters returns the parameters of the method.
 func (m *Method) Parameters() ParameterSlice {
 	return m.parameters
@@ -80,8 +61,8 @@ func (m *Method) AddParameter(parameter *Parameter) {
 	}
 }
 
-// Get parameter returns the parameter with the given name, or nil if there is no parameter with
-// that name.
+// GetParameter returns the parameter with the given name, or nil if there is no parameter with that
+// name.
 func (m *Method) GetParameter(name *names.Name) *Parameter {
 	if name == nil {
 		return nil

--- a/pkg/concepts/named.go
+++ b/pkg/concepts/named.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 Red Hat, Inc.
+Copyright (c) 2021 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,28 +16,21 @@ limitations under the License.
 
 package concepts
 
-// Documented is implemented by concepts that have documentation.
-type Documented interface {
-	// Doc returns the documentation attached to the object.
-	Doc() string
+import "github.com/openshift-online/ocm-api-metamodel/pkg/names"
 
-	// SetDoc sets the documentation attached to the object.
-	SetDoc(doc string)
-}
-
-// documentedSupport is an implementation of the Documented interface intended to be embedded in
+// namedSupport is an implementation of the names.Named interface intended to be embeded in other
 // types that need to implement that interface.
-type documentedSupport struct {
-	doc string
+type namedSupport struct {
+	name *names.Name
 }
 
 // Make sure we implement the interface:
-var _ Documented = &documentedSupport{}
+var _ names.Named = &namedSupport{}
 
-func (s *documentedSupport) Doc() string {
-	return s.doc
+func (s *namedSupport) Name() *names.Name {
+	return s.name
 }
 
-func (s *documentedSupport) SetDoc(doc string) {
-	s.doc = doc
+func (s *namedSupport) SetName(value *names.Name) {
+	s.name = value
 }

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -23,9 +23,10 @@ import (
 
 // Parameter represents a parameter of a method.
 type Parameter struct {
+	documentedSupport
+	namedSupport
+
 	owner *Method
-	doc   string
-	name  *names.Name
 	typ   *Type
 	in    bool
 	out   bool
@@ -45,26 +46,6 @@ func (p *Parameter) Owner() *Method {
 // SetOwner sets the method that owns this parameter.
 func (p *Parameter) SetOwner(value *Method) {
 	p.owner = value
-}
-
-// Doc returns the documentation of this parameter.
-func (p *Parameter) Doc() string {
-	return p.doc
-}
-
-// SetDoc sets the documentation of this parameter.
-func (p *Parameter) SetDoc(value string) {
-	p.doc = value
-}
-
-// Name returns the name of the parameter.
-func (p *Parameter) Name() *names.Name {
-	return p.name
-}
-
-// SetName sets the name of the parameter.
-func (p *Parameter) SetName(value *names.Name) {
-	p.name = value
 }
 
 // Type returns the type of the parameter.

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -24,9 +24,10 @@ import (
 
 // Resource represents an API resource.
 type Resource struct {
+	documentedSupport
+	namedSupport
+
 	owner    *Version
-	doc      string
-	name     *names.Name
 	methods  MethodSlice
 	locators LocatorSlice
 }
@@ -44,26 +45,6 @@ func (r *Resource) Owner() *Version {
 // SetOwner sets the version that owns the resource.
 func (r *Resource) SetOwner(value *Version) {
 	r.owner = value
-}
-
-// Doc returns the documentation of this resource.
-func (r *Resource) Doc() string {
-	return r.doc
-}
-
-// SetDoc sets the documentation of this resource.
-func (r *Resource) SetDoc(value string) {
-	r.doc = value
-}
-
-// Name returns the name of the resource.
-func (r *Resource) Name() *names.Name {
-	return r.name
-}
-
-// SetName sets the name of the resource.
-func (r *Resource) SetName(value *names.Name) {
-	r.name = value
 }
 
 // Methods returns the methods of the resource.

--- a/pkg/concepts/service.go
+++ b/pkg/concepts/service.go
@@ -25,41 +25,31 @@ import (
 // Service is the representation of service, containing potentiall mutiple versions, for example the
 // clusters management service.
 type Service struct {
+	documentedSupport
+	namedSupport
+
 	// Model that owns this service:
 	owner *Model
-
-	// Name of the service:
-	name *names.Name
 
 	// All the versions of the service, indexed by name:
 	versions map[string]*Version
 }
 
-// NewVersion creates a new empty service.
+// NewService creates a new empty service.
 func NewService() *Service {
 	service := new(Service)
 	service.versions = make(map[string]*Version)
 	return service
 }
 
-// Onwer returns the model that owns this service.
+// Owner returns the model that owns this service.
 func (s *Service) Owner() *Model {
 	return s.owner
 }
 
-// SetOnwer sets the model that owns this service.
+// SetOwner sets the model that owns this service.
 func (s *Service) SetOwner(value *Model) {
 	s.owner = value
-}
-
-// Name returns the name of this service.
-func (s *Service) Name() *names.Name {
-	return s.name
-}
-
-// SetName sets the name of this service.
-func (s *Service) SetName(value *names.Name) {
-	s.name = value
 }
 
 // Versions returns the list of versions of the service.

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -68,10 +68,11 @@ func NewType() *Type {
 
 // Type specifies the data type of attributes of structs and method parameters.
 type Type struct {
+	documentedSupport
+	namedSupport
+
 	owner      *Version
-	doc        string
 	kind       TypeKind
-	name       *names.Name
 	attributes AttributeSlice
 	values     EnumValueSlice
 	element    *Type
@@ -86,16 +87,6 @@ func (t *Type) Owner() *Version {
 // SetOwner sets the version that owns this type.
 func (t *Type) SetOwner(value *Version) {
 	t.owner = value
-}
-
-// Doc returns the documentation of this type.
-func (t *Type) Doc() string {
-	return t.doc
-}
-
-// SetDoc sets the documentation of this type.
-func (t *Type) SetDoc(value string) {
-	t.doc = value
 }
 
 // Kind returns the kind of this type.
@@ -175,16 +166,6 @@ func (t *Type) IsStruct() bool {
 	return t.kind == ClassType || t.kind == StructType
 }
 
-// Name returns the name of this type.
-func (t *Type) Name() *names.Name {
-	return t.name
-}
-
-// SetName sets the name of this type.
-func (t *Type) SetName(value *names.Name) {
-	t.name = value
-}
-
 // Attributes returns the list of attributes of an struct type. If called for any other kind of type
 // it will return nil.
 func (t *Type) Attributes() AttributeSlice {
@@ -254,9 +235,10 @@ func (s TypeSlice) Swap(i, j int) {
 
 // EnumValue represents each of the values of an enum type.
 type EnumValue struct {
-	typ  *Type
-	doc  string
-	name *names.Name
+	documentedSupport
+	namedSupport
+
+	typ *Type
 }
 
 // NewEnumValue creates a new enumerated type value.
@@ -272,26 +254,6 @@ func (v *EnumValue) Type() *Type {
 // SetType sets the enum type that owns this value.
 func (v *EnumValue) SetType(value *Type) {
 	v.typ = value
-}
-
-// Doc returns the documentation of this value.
-func (v *EnumValue) Doc() string {
-	return v.doc
-}
-
-// SetDoc sets the documentation of this value.
-func (v *EnumValue) SetDoc(value string) {
-	v.doc = value
-}
-
-// Name return the name of this enum value.
-func (v *EnumValue) Name() *names.Name {
-	return v.name
-}
-
-// SetName sets the name of this enum value.
-func (v *EnumValue) SetName(value *names.Name) {
-	v.name = value
 }
 
 // EnumValueSlice is used to simplify sorting of slices of enum values by name.

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -25,11 +25,11 @@ import (
 
 // Version is the representation of a version of a service.
 type Version struct {
+	documentedSupport
+	namedSupport
+
 	// Service that owns this version:
 	owner *Service
-
-	// Name of the version:
-	name *names.Name
 
 	// All the types of the version, indexed by name:
 	types map[string]*Type
@@ -74,16 +74,6 @@ func (v *Version) Owner() *Service {
 // SetOwner sets the service that owns this version.
 func (v *Version) SetOwner(value *Service) {
 	v.owner = value
-}
-
-// Name returns the name of this version.
-func (v *Version) Name() *names.Name {
-	return v.name
-}
-
-// SetName sets the name of this version.
-func (v *Version) SetName(value *names.Name) {
-	v.name = value
 }
 
 // Types returns the list of types that are part of this version.

--- a/pkg/names/named.go
+++ b/pkg/names/named.go
@@ -20,3 +20,17 @@ package names
 type Named interface {
 	Name() *Name
 }
+
+// namedSupport is an implementation of the Named interface intended to be embeded in other types
+// that need to implement that interface.
+type namedSupport struct {
+	name *Name
+}
+
+func (s *namedSupport) Name() *Name {
+	return s.name
+}
+
+func (s *namedSupport) SetName(value *Name) {
+	s.name = value
+}


### PR DESCRIPTION
This patch adds a new `documentedSupport` and `namedSupport` types that are
embedded in all types that need to implement the `Documented` and `Named`
interface. This reduces the duplication of code associated to the
implementation of those interfaces.