### PR TITLE
Add `typedSupport`

### DIFF
--- a/pkg/concepts/attribute.go
+++ b/pkg/concepts/attribute.go
@@ -24,10 +24,10 @@ import (
 type Attribute struct {
 	documentedSupport
 	namedSupport
+	typedSupport
 
 	owner *Type
 	link  bool
-	typ   *Type
 }
 
 // NewAttribute creates a new attribute.
@@ -53,16 +53,6 @@ func (a *Attribute) Link() bool {
 // SetLink sets the flag that indicates if this attribute is a link.
 func (a *Attribute) SetLink(value bool) {
 	a.link = value
-}
-
-// Type returns the type of the attribute.
-func (a *Attribute) Type() *Type {
-	return a.typ
-}
-
-// SetType sets the type of the attribute.
-func (a *Attribute) SetType(value *Type) {
-	a.typ = value
 }
 
 // AttributeSlice is used to simplify sorting of slices of attributes by name.

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -25,9 +25,9 @@ import (
 type Parameter struct {
 	documentedSupport
 	namedSupport
+	typedSupport
 
 	owner *Method
-	typ   *Type
 	in    bool
 	out   bool
 	dflt  interface{}
@@ -46,16 +46,6 @@ func (p *Parameter) Owner() *Method {
 // SetOwner sets the method that owns this parameter.
 func (p *Parameter) SetOwner(value *Method) {
 	p.owner = value
-}
-
-// Type returns the type of the parameter.
-func (p *Parameter) Type() *Type {
-	return p.typ
-}
-
-// SetType sets the type of the parameter.
-func (p *Parameter) SetType(value *Type) {
-	p.typ = value
 }
 
 // In returns true if this is an input parameter.

--- a/pkg/concepts/typed.go
+++ b/pkg/concepts/typed.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concepts
+
+// Typed is implemented by concepts that have a type.
+type Typed interface {
+	// Type returns the type of the object.
+	Type() *Type
+
+	// SetType sets the type of the object.
+	SetType(typ *Type)
+}
+
+// typedSupport is an implementation of the Typed interface intended to be embedded in types that
+// need to implement that interface.
+type typedSupport struct {
+	typ *Type
+}
+
+// Make sure we implement the interface:
+var _ Typed = &typedSupport{}
+
+func (s *typedSupport) Type() *Type {
+	return s.typ
+}
+
+func (s *typedSupport) SetType(typ *Type) {
+	s.typ = typ
+}


### PR DESCRIPTION
This patch adds a new `typedSupport` to avoid repeating the implementation of
the `Type` and `GetType` methods.