### PR TITLE
Make reporter streams configurable

### DIFF
--- a/cmd/check/cmd.go
+++ b/cmd/check/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package check
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,11 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	// Create the reporter:
-	reporter := reporter.NewReporter()
+	reporter, err := reporter.New().Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build reporter: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Check command line options:
 	ok := true
@@ -66,7 +71,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Read the model:
-	_, err := language.NewReader().
+	_, err = language.NewReader().
 		Reporter(reporter).
 		Inputs(args.paths).
 		Read()

--- a/cmd/generate/docs/cmd.go
+++ b/cmd/generate/docs/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docs
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -62,7 +63,11 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	// Create the reporter:
-	reporter := reporter.NewReporter()
+	reporter, err := reporter.New().Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build reporter: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Check command line options:
 	ok := true

--- a/cmd/generate/golang/cmd.go
+++ b/cmd/generate/golang/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package golang
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,7 +75,11 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	// Create the reporter:
-	reporter := reporter.NewReporter()
+	reporter, err := reporter.New().Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build reporter: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Check command line options:
 	ok := true

--- a/cmd/generate/openapi/cmd.go
+++ b/cmd/generate/openapi/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openapi
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -63,7 +64,11 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	// Create the reporter:
-	reporter := reporter.NewReporter()
+	reporter, err := reporter.New().Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build reporter: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Check command line options:
 	ok := true


### PR DESCRIPTION
This patch changes the reporter so that the streams it uses to write messages
are configurable. This is intended for use in tests, where we will want to
write to the output of the testing framework instead of to the standard output.