### PR TITLE
Add metrics support generator

### DIFF
--- a/cmd/generate/golang/cmd.go
+++ b/cmd/generate/golang/cmd.go
@@ -243,7 +243,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	gens = append(gens, gen)
 
-	// Create the JSON readers generator:
+	// Create the JSON support generator:
 	gen, err = golang.NewJSONSupportGenerator().
 		Reporter(reporter).
 		Model(model).
@@ -254,7 +254,22 @@ func run(cmd *cobra.Command, argv []string) {
 		Binding(bindingCalculator).
 		Build()
 	if err != nil {
-		reporter.Errorf("Can't create JSON readers generator: %v", err)
+		reporter.Errorf("Can't create JSON support generator: %v", err)
+		os.Exit(1)
+	}
+	gens = append(gens, gen)
+
+	// Create the metrics support generator:
+	gen, err = golang.NewMetricsSupportGenerator().
+		Reporter(reporter).
+		Model(model).
+		Output(args.output).
+		Packages(goPackagesCalculator).
+		Names(goNamesCalculator).
+		Binding(bindingCalculator).
+		Build()
+	if err != nil {
+		reporter.Errorf("Can't create metrics support generator: %v", err)
 		os.Exit(1)
 	}
 	gens = append(gens, gen)

--- a/pkg/generators/golang/buffer.go
+++ b/pkg/generators/golang/buffer.go
@@ -126,6 +126,7 @@ func (b *BufferBuilder) Build() (buffer *Buffer, err error) {
 	buffer.functions = make(map[string]interface{})
 	buffer.functions["lineComment"] = buffer.lineComment
 	buffer.functions["byteArray"] = buffer.byteArray
+	buffer.functions["backtick"] = buffer.backtick
 	for name, function := range b.functions {
 		buffer.functions[name] = function
 	}
@@ -462,6 +463,20 @@ func (b *Buffer) cleanPkg(name string) string {
 		name = name[index+1:]
 	}
 	return name
+}
+
+// backtick generates the ` character. This is intended for templats tht need to include this
+// character, but that are already using it to define the template itself. For example:
+//
+//	// Generate a multi-line string using the backtick syntax:
+//	g.buffer.Emit(`
+//		var myString = {{ backtick }}
+//			First line
+//			Second line
+//		{{ backtick }}
+//		`,
+func (b *Buffer) backtick() string {
+	return "`"
 }
 
 // Header that will be included in all generated files:

--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -177,14 +177,12 @@ func (g *HelpersGenerator) Run() error {
 			header.Add(name, fmt.Sprintf("%v", value))
 		}
 
-		// SetHeader creates a copy of the given set of headers, and adds the header
-		// containing the given metrics path.
-		func SetHeader(header http.Header, metric string) http.Header {
+		// CopyHeader creates a copy of the given set of headers.
+		func CopyHeader(header http.Header) http.Header {
 			result := make(http.Header)
 			for name, values := range header {
 				result[name] = CopyValues(values)
 			}
-			result.Set(metricHeader, metric)
 			return result
 		}
 
@@ -291,9 +289,6 @@ func (g *HelpersGenerator) Run() error {
 			}
 			return true
 		}
-
-		// Name of the header used to contain the metrics path:
-		const metricHeader = "X-Metric"
         `)
 
 	// Write the generated code:

--- a/pkg/generators/golang/metrics_generator.go
+++ b/pkg/generators/golang/metrics_generator.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package golang
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+)
+
+// MetricsSupportGeneratorBuilder is an object used to configure and build the Metrics support
+// generator. Don't create instances directly, use the NewMetricsSupportGenerator function instead.
+type MetricsSupportGeneratorBuilder struct {
+	reporter *reporter.Reporter
+	model    *concepts.Model
+	output   string
+	packages *PackagesCalculator
+	names    *NamesCalculator
+	binding  *http.BindingCalculator
+}
+
+// MetricsSupportGenerator generates metrics support code. Don't create instances directly, use the
+// builder instead.
+type MetricsSupportGenerator struct {
+	reporter *reporter.Reporter
+	model    *concepts.Model
+	output   string
+	packages *PackagesCalculator
+	names    *NamesCalculator
+	buffer   *Buffer
+	binding  *http.BindingCalculator
+}
+
+// NewMetricsSupportGenerator creates a new builder metrics support code generator.
+func NewMetricsSupportGenerator() *MetricsSupportGeneratorBuilder {
+	return &MetricsSupportGeneratorBuilder{}
+}
+
+// Reporter sets the object that will be used to report information about the generation process,
+// including errors.
+func (b *MetricsSupportGeneratorBuilder) Reporter(
+	value *reporter.Reporter) *MetricsSupportGeneratorBuilder {
+	b.reporter = value
+	return b
+}
+
+// Model sets the model that will be used by the generator.
+func (b *MetricsSupportGeneratorBuilder) Model(value *concepts.Model) *MetricsSupportGeneratorBuilder {
+	b.model = value
+	return b
+}
+
+// Output sets import path of the output package.
+func (b *MetricsSupportGeneratorBuilder) Output(value string) *MetricsSupportGeneratorBuilder {
+	b.output = value
+	return b
+}
+
+// Packages sets the object that will be used to calculate package names.
+func (b *MetricsSupportGeneratorBuilder) Packages(
+	value *PackagesCalculator) *MetricsSupportGeneratorBuilder {
+	b.packages = value
+	return b
+}
+
+// Names sets the object that will be used to calculate names.
+func (b *MetricsSupportGeneratorBuilder) Names(value *NamesCalculator) *MetricsSupportGeneratorBuilder {
+	b.names = value
+	return b
+}
+
+// Binding sets the object that will by used to do HTTP binding calculations.
+func (b *MetricsSupportGeneratorBuilder) Binding(
+	value *http.BindingCalculator) *MetricsSupportGeneratorBuilder {
+	b.binding = value
+	return b
+}
+
+// Build checks the configuration stored in the builder and, if it is correct, creates a new types
+// generator using it.
+func (b *MetricsSupportGeneratorBuilder) Build() (generator *MetricsSupportGenerator, err error) {
+	// Check that the mandatory parameters have been provided:
+	if b.reporter == nil {
+		err = fmt.Errorf("reporter is mandatory")
+		return
+	}
+	if b.model == nil {
+		err = fmt.Errorf("model is mandatory")
+		return
+	}
+	if b.output == "" {
+		err = fmt.Errorf("output is mandatory")
+		return
+	}
+	if b.packages == nil {
+		err = fmt.Errorf("packages calculator is mandatory")
+		return
+	}
+	if b.names == nil {
+		err = fmt.Errorf("names calculator is mandatory")
+		return
+	}
+
+	// Create the generator:
+	generator = &MetricsSupportGenerator{
+		reporter: b.reporter,
+		model:    b.model,
+		output:   b.output,
+		packages: b.packages,
+		names:    b.names,
+	}
+
+	return
+}
+
+// Run executes the code generator.
+func (g *MetricsSupportGenerator) Run() error {
+	var err error
+
+	// Calculate the package and file name:
+	pkgName := g.packages.MetricsPackage()
+	fileName := g.names.File(names.Cat(nomenclator.Path, nomenclator.Tree, nomenclator.Data))
+
+	// Create the buffer for the generated code:
+	g.buffer, err = NewBuffer().
+		Reporter(g.reporter).
+		Output(g.output).
+		Packages(g.packages).
+		Package(pkgName).
+		File(fileName).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	// Build the tree and serialize it to JSON:
+	apiBranch := map[string]interface{}{}
+	for _, service := range g.model.Services() {
+		serviceBranch := map[string]interface{}{}
+		for _, version := range service.Versions() {
+			versionBranch := g.resourceBranch(version.Root())
+			versionLabel := g.binding.VersionSegment(version)
+			serviceBranch[versionLabel] = versionBranch
+		}
+		serviceLabel := g.binding.ServiceSegment(service)
+		apiBranch[serviceLabel] = serviceBranch
+	}
+	mainBranch := map[string]interface{}{
+		"api": apiBranch,
+	}
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetIndent("", "  ")
+	err = encoder.Encode(mainBranch)
+	if err != nil {
+		return err
+	}
+	data := buffer.String()
+
+	// Generate the code:
+	g.buffer.Emit(`
+		// pathTreeData is the JSON representation of the tree of URL paths.
+		var pathTreeData = {{ backtick }}{{ .Data }}{{ backtick }}
+		`,
+		"Data", data,
+	)
+
+	// Write the generated code:
+	return g.buffer.Write()
+}
+
+func (g *MetricsSupportGenerator) resourceBranch(resource *concepts.Resource) interface{} {
+	// Check if the target resource has any locator of action method. If it hasn't it does't
+	// need an additional branch.
+	locators := resource.Locators()
+	var actions []*concepts.Method
+	for _, method := range resource.Methods() {
+		if method.IsAction() {
+			actions = append(actions, method)
+		}
+	}
+	if len(locators) == 0 && len(actions) == 0 {
+		return nil
+	}
+
+	// If the target has locators or action methods then populate the branch:
+	branch := map[string]interface{}{}
+	for _, action := range actions {
+		actionLabel := g.binding.MethodSegment(action)
+		branch[actionLabel] = nil
+	}
+	for _, locator := range locators {
+		locatorLabel := g.binding.LocatorSegment(locator)
+		if locator.Variable() {
+			locatorLabel = "-"
+		}
+		locatorBranch := g.resourceBranch(locator.Target())
+		branch[locatorLabel] = locatorBranch
+	}
+	return branch
+}

--- a/pkg/generators/golang/packages_calculator.go
+++ b/pkg/generators/golang/packages_calculator.go
@@ -107,7 +107,7 @@ func (g *PackagesCalculator) VersionImport(version *concepts.Version) string {
 	return path.Join(g.base, g.VersionPackage(version))
 }
 
-// ServiceSelector returns the selector of the package for the given service.
+// VersionSelector returns the selector of the package for the given service.
 func (g *PackagesCalculator) VersionSelector(version *concepts.Version) string {
 	return path.Base(g.VersionPackage(version))
 }
@@ -119,6 +119,16 @@ func (g *PackagesCalculator) HelpersPackage() string {
 
 // HelpersImport returns complete import path of the helpers package.
 func (g *PackagesCalculator) HelpersImport() string {
+	return path.Join(g.base, g.HelpersPackage())
+}
+
+// MetricsPackage returns the name of the metrics package.
+func (g *PackagesCalculator) MetricsPackage() string {
+	return nomenclator.Metrics.LowerJoined("")
+}
+
+// MetricsImport returns complete import path of the metrics package.
+func (g *PackagesCalculator) MetricsImport() string {
 	return path.Join(g.base, g.HelpersPackage())
 }
 

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -79,6 +79,7 @@ var (
 	Marshal  = names.ParseUsingCase("Marshal")
 	Metadata = names.ParseUsingCase("Metadata")
 	Method   = names.ParseUsingCase("Method")
+	Metrics  = names.ParseUsingCase("Metrics")
 
 	// N:
 	New = names.ParseUsingCase("New")
@@ -86,8 +87,9 @@ var (
 	// P:
 	Page  = names.ParseUsingCase("Page")
 	Parse = names.ParseUsingCase("Parse")
-	Post  = names.ParseUsingCase("Post")
+	Path  = names.ParseUsingCase("Path")
 	Poll  = names.ParseUsingCase("Poll")
+	Post  = names.ParseUsingCase("Post")
 
 	// R:
 	Read     = names.ParseUsingCase("Read")
@@ -111,6 +113,7 @@ var (
 
 	// T:
 	Total = names.ParseUsingCase("Total")
+	Tree  = names.ParseUsingCase("Tree")
 	Type  = names.ParseUsingCase("Type")
 
 	// U:

--- a/tests/go/clients_test.go
+++ b/tests/go/clients_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Client", func() {
 		server.AppendHandlers(RespondWith(http.StatusOK, `{
 			"auths": {}
 		}`))
-		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1", "")
+		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
 		response, err := client.AccessToken().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -64,7 +64,7 @@ var _ = Describe("Client", func() {
 				}
 			}
 		}`))
-		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1", "")
+		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
 		response, err := client.AccessToken().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -89,7 +89,7 @@ var _ = Describe("Client", func() {
 				}
 			}
 		}`))
-		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1", "")
+		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
 		response, err := client.AccessToken().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -109,7 +109,7 @@ var _ = Describe("Client", func() {
 		server.AppendHandlers(RespondWith(http.StatusOK, `{
 			"server_version": "123"
 		}`))
-		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1", "")
+		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1")
 		response, err := client.Get().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -155,7 +155,7 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Send the request:
-		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1", "")
+		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1")
 		response, err := client.RegisterDisconnected().
 			Cluster(cluster).
 			Send()
@@ -196,7 +196,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1", "")
+		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1")
 		response, err := client.RegisterCluster().
 			SubscriptionID("123").
 			ExternalID("456").
@@ -225,7 +225,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -253,7 +253,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -287,7 +287,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -332,7 +332,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -369,7 +369,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().
 			Page(123).
 			Size(456).
@@ -399,7 +399,7 @@ var _ = Describe("Client", func() {
 		)
 
 		// Send the request:
-		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters", "")
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
 		response, err := client.List().Send()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
@@ -422,7 +422,7 @@ var _ = Describe("Client", func() {
 			)
 
 			// Send the request:
-			client := cmv1.NewClusterClient(transport, "", "")
+			client := cmv1.NewClusterClient(transport, "")
 			_, err := client.Get().Parameter("my", value).Send()
 			Expect(err).ToNot(HaveOccurred())
 		},

--- a/tests/go/poll_test.go
+++ b/tests/go/poll_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Poll", func() {
 	})
 
 	It("Refuses to start without a timeout or deadline", func() {
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx := context.Background()
 		_, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -53,7 +53,7 @@ var _ = Describe("Poll", func() {
 	})
 
 	It("Refuses to start without an interval", func() {
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			StartContext(ctx)
@@ -61,7 +61,7 @@ var _ = Describe("Poll", func() {
 	})
 
 	It("Refuses to start without zero interval", func() {
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(0).
@@ -70,7 +70,7 @@ var _ = Describe("Poll", func() {
 	})
 
 	It("Refuses to start without negative interval", func() {
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(-1 * time.Millisecond).
@@ -85,7 +85,7 @@ var _ = Describe("Poll", func() {
 			"href": "/api/clusters_mgmt/v1/clusters/123",
 			"name": "mycluster"
 		}`))
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -108,11 +108,7 @@ var _ = Describe("Poll", func() {
 			"code": "CLUSTERS-MGMT-404",
 			"reason": "Not found"
 		}`))
-		client := cmv1.NewClusterClient(
-			transport,
-			"/api/clusters_mgmt/v1/clusters/123",
-			"",
-		)
+		client := cmv1.NewClusterClient(transport, "/api/clusters_mgmt/v1/clusters/123")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Minute)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -142,7 +138,7 @@ var _ = Describe("Poll", func() {
 			"href": "/api/clusters_mgmt/v1/clusters/123",
 			"name": "mycluster"
 		}`))
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -170,7 +166,7 @@ var _ = Describe("Poll", func() {
 			"href": "/api/clusters_mgmt/v1/clusters/123",
 			"name": "mycluster"
 		}`))
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -196,7 +192,7 @@ var _ = Describe("Poll", func() {
 				"name": "mycluster"
 			}`),
 		)
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -214,7 +210,7 @@ var _ = Describe("Poll", func() {
 			"name": "mycluster",
 			"state": "ready"
 		}`))
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
@@ -247,7 +243,7 @@ var _ = Describe("Poll", func() {
 			"name": "mycluster",
 			"state": "ready"
 		}`))
-		client := cmv1.NewClusterClient(transport, "", "")
+		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).


### PR DESCRIPTION
This patch adds a new code generator that generates the
`path_tree_data.go` file containing the tree of URL paths that the
metrics round tripper of the SDK will use to calculate the `path` label
of metrics. This means that it is no longer necessary to use the
`X-Metric` header to carry the value of that label, so the patch also
removes all uses of that header.