### PR TITLE
Release 0.0.38

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.38 Jul 6 2021
+
+- Explicitly import `github.com/golang/glog` to avoid conflicts with
+  `github.com/istio/glog`.
+
 == 0.0.37 Feb 15 2021
 
 - Add metrics support generator, and remove `X-Metric` header.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.37"
+const Version = "0.0.38"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Explicitly import `github.com/golang/glog` to avoid conflicts with
  `github.com/istio/glog`.