### PR TITLE
SDA-4587 : add details to errors

### DIFF
--- a/tests/go/builders_test.go
+++ b/tests/go/builders_test.go
@@ -211,6 +211,8 @@ var _ = Describe("Builder", func() {
 				Code("CLUSTERS-MGMT-401").
 				Reason("My reason").
 				OperationID("456").
+				Details(map[string]interface{}{
+					"kind": "cluster error"}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(object.ID()).To(Equal("401"))
@@ -218,6 +220,8 @@ var _ = Describe("Builder", func() {
 			Expect(object.Code()).To(Equal("CLUSTERS-MGMT-401"))
 			Expect(object.Reason()).To(Equal("My reason"))
 			Expect(object.OperationID()).To(Equal("456"))
+			Expect(object.Details()).To(Equal(map[string]interface{}{
+				"kind": "cluster error"}))
 		})
 	})
 

--- a/tests/go/marshal_test.go
+++ b/tests/go/marshal_test.go
@@ -178,6 +178,8 @@ var _ = Describe("Marshal", func() {
 			Code("CLUSTERS-MGMT-401").
 			Reason("My reason").
 			OperationID("456").
+			Details(map[string]interface{}{
+				"kind": "cluster error"}).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 		buffer := new(bytes.Buffer)
@@ -189,7 +191,8 @@ var _ = Describe("Marshal", func() {
 			"href": "/api/clusters_mgmt/v1/errors/401",
 			"code": "CLUSTERS-MGMT-401",
 			"reason": "My reason",
-			"operation_id": "456"
+			"operation_id": "456",
+			"details": {"kind" : "cluster error"}
 		}`))
 	})
 

--- a/tests/go/unmarshal_test.go
+++ b/tests/go/unmarshal_test.go
@@ -470,7 +470,8 @@ var _ = Describe("Unmarshal", func() {
 			"href": "/api/clusters_mgmt/v1/errors/401",
 			"code": "CLUSTERS-MGMT-401",
 			"reason": "My reason",
-			"operation_id": "456"
+			"operation_id": "456",
+			"details": {"kind" : "cluster error"}
 		}`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object).ToNot(BeNil())
@@ -480,6 +481,8 @@ var _ = Describe("Unmarshal", func() {
 		Expect(object.Code()).To(Equal("CLUSTERS-MGMT-401"))
 		Expect(object.Reason()).To(Equal("My reason"))
 		Expect(object.OperationID()).To(Equal("456"))
+		Expect(object.Details()).To(Equal(map[string]interface{}{
+			"kind": "cluster error"}))
 	})
 
 	It("Can read mixed known and unknown attributes", func() {


### PR DESCRIPTION
Part of : https://issues.redhat.com/browse/SDA-4587

This change adds details object to errors