### PR TITLE
Release 0.0.39

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.39 Aug 23 2021
+
+- Add `details` attribute to errors.
+
 == 0.0.38 Jul 6 2021
 
 - Explicitly import `github.com/golang/glog` to avoid conflicts with

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.38"
+const Version = "0.0.39"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add `details` attribute to errors.