### PR TITLE
Release 0.0.42

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.42 Oct 14 2021
+
+- Accept iterator as parameter in `helpers.NewIterator`.
+
 == 0.0.41 Sep 24 2021
 
 The only change in this release is that the _GitHub_ action that publishes

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.41"
+const Version = "0.0.42"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Accept iterator as parameter in `helpers.NewIterator`.