### PR TITLE
Release 0.0.43

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+== 0.0.43 Nov 15 2021
+
+- Add `status` attribute to errors.
+
 == 0.0.42 Oct 14 2021
 
 - Accept iterator as parameter in `helpers.NewIterator`.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.42"
+const Version = "0.0.43"


### PR DESCRIPTION
The only relevant change in the new version is the addition of the
`status` attribute to errors.