### PR TITLE
Add `Empty` method to builders

### DIFF
--- a/pkg/generators/golang/builders_generator.go
+++ b/pkg/generators/golang/builders_generator.go
@@ -259,6 +259,15 @@ func (g *BuildersGenerator) generateStructBuilderSource(typ *concepts.Type) {
 			}
 		{{ end }}
 
+		// Empty returns true if the builder is empty, i.e. no attribute has a value.
+		func (b *{{ $builderName }}) Empty() bool {
+			{{ if .Type.IsClass }}
+				return b == nil || b.bitmap_&^1 == 0
+			{{ else }}
+				return b == nil || b.bitmap_ == 0
+			{{ end }}
+		}
+
 		{{ range .Type.Attributes }}
 			{{ $fieldName := fieldName . }}
 			{{ $setterName := setterName . }}
@@ -502,6 +511,11 @@ func (g *BuildersGenerator) generateStructListBuilderSource(typ *concepts.Type) 
                         b.items = make([]*{{ $elementBuilderName }}, len(values))
                         copy(b.items, values)
 			return b
+		}
+
+		// Empty returns true if the list is empty.
+		func (b *{{ $builderName }}) Empty() bool {
+			return b == nil || len(b.items) == 0
 		}
 
 		// Copy copies the items of the given list into this builder, discarding any previous items.

--- a/tests/go/builders_test.go
+++ b/tests/go/builders_test.go
@@ -365,4 +365,107 @@ var _ = Describe("Builder", func() {
 			Expect(second.Email()).To(Equal("yourmail"))
 		})
 	})
+
+	Describe("Empty", func() {
+		It("Returns `true` for nil builder ", func() {
+			var builder *cmv1.ClusterBuilder
+			Expect(builder.Empty()).To(BeTrue())
+		})
+
+		It("Returns `true` for an empty builder", func() {
+			builder := cmv1.NewCluster()
+			Expect(builder.Empty()).To(BeTrue())
+		})
+
+		It("Returns `false` for an builder with identifier", func() {
+			builder := cmv1.NewCluster().
+				ID("123")
+			Expect(builder.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for an builder with an string attribute", func() {
+			builder := cmv1.NewCluster().
+				Name("mycluster")
+			Expect(builder.Empty()).To(BeFalse())
+		})
+
+		It("Returns `true` for nil list ", func() {
+			var list *cmv1.ClusterListBuilder
+			Expect(list.Empty()).To(BeTrue())
+		})
+
+		It("Returns `true` for empty list ", func() {
+			list := cmv1.NewClusterList()
+			Expect(list.Empty()).To(BeTrue())
+		})
+
+		It("Returns `false` for list with one element", func() {
+			list := cmv1.NewClusterList().
+				Items(
+					cmv1.NewCluster().ID("123"),
+				)
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for list with two elements", func() {
+			list := cmv1.NewClusterList().
+				Items(
+					cmv1.NewCluster().ID("123"),
+					cmv1.NewCluster().ID("456"),
+				)
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for empty map of strings", func() {
+			list := cmv1.NewCluster().
+				Properties(map[string]string{})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of strings with one value", func() {
+			list := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey": "myvalue",
+				})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of strings with two values", func() {
+			list := cmv1.NewCluster().
+				Properties(map[string]string{
+					"mykey":   "myvalue",
+					"yourkey": "yourvalue",
+				})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for empty map of builders", func() {
+			list := amv1.NewRegistryAuths().
+				Map(map[string]*amv1.RegistryAuthBuilder{})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of builders with one value", func() {
+			list := amv1.NewRegistryAuths().
+				Map(map[string]*amv1.RegistryAuthBuilder{
+					"my.com": amv1.NewRegistryAuth().Username("myuser"),
+				})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `false` for map of builders with one value", func() {
+			list := amv1.NewRegistryAuths().
+				Map(map[string]*amv1.RegistryAuthBuilder{
+					"my.com":   amv1.NewRegistryAuth().Username("myuser"),
+					"your.com": amv1.NewRegistryAuth().Username("youruser"),
+				})
+			Expect(list.Empty()).To(BeFalse())
+		})
+
+		It("Returns `true` empty link", func() {
+			builder := cmv1.NewCluster().
+				Link(true)
+			Expect(builder.Empty()).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
This patch adds a new `Empty` method to builders that simplifies
checking if any attribute has been set.