### PR TITLE
Canel poll context

### DIFF
--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -232,6 +232,7 @@ func (g *HelpersGenerator) Run() error {
 			// Create a cancellable context so that we can explicitly cancel it when we know that the next
 			// iteration of the loop will be after the deadline:
 			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
 			// If no expected status has been explicitly specified then add the default:
 			if len(statuses) == 0 {


### PR DESCRIPTION
This patch changes the `PollContext` function so that it always cancels
the deadline context that it creates.