### PR TITLE
Release 0.0.46

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+## 0.0.46 Dec 20 2021
+
+- Remove unused imports.
+- Check result of `Flush` method.
+- Cancel poll context.
+- Avoid some ineffectual assigments.
+- Explicitly use `jsoniter` package selector.
+
 ## 0.0.45 Dec 3 2021
 
 The only functional change in this version is the change from _Markdown_ to

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.45"
+const Version = "0.0.46"


### PR DESCRIPTION
The more relevant changes in the new release are the following:

- Remove unused imports.
- Check result of `Flush` method.
- Cancel poll context.
- Avoid some ineffectual assigments.
- Explicitly use `jsoniter` package selector.