### PR TITLE
Fix release of windows artifacts

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -78,8 +78,11 @@ jobs:
             subprocess.run(check=True, env=env, args=args)
 
             # Copy the generated binary to the assets directory:
+            asset = "metamodel"
+            if goos == "windows":
+                asset += ".exe"
             binary = os.path.join(assets, f"metamodel-{goos}-{goarch}")
-            os.rename("metamodel", binary)
+            os.rename(asset, binary)
 
         # Build for the supported operating systems and architectures:
         build("darwin", "amd64")


### PR DESCRIPTION
Currently the release process assumes that the name of the binary file
is `metamodel`, but in Windows it is `metamodel.exe`. As a result the
release process fails because it doesn't find the asset to upload. This
patch fixes that issue.