### PR TITLE
Fix format of date query parameters

### DIFF
--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -153,7 +153,14 @@ func (g *HelpersGenerator) Run() error {
 			if *query == nil {
 				*query = make(url.Values)
 			}
-			query.Add(name, fmt.Sprintf("%v", value))
+			var text string
+			switch typed := value.(type) {
+			case time.Time:
+				text = typed.UTC().Format(time.RFC3339)
+			default:
+				text = fmt.Sprintf("%v", value)
+			}
+			query.Add(name, text)
 		}
 
 		// CopyQuery creates a copy of the given set of query parameters.

--- a/tests/go/servers_test.go
+++ b/tests/go/servers_test.go
@@ -32,6 +32,7 @@ import (
 	az "github.com/openshift-online/ocm-api-metamodel/tests/go/generated/authorizations"
 	cm "github.com/openshift-online/ocm-api-metamodel/tests/go/generated/clustersmgmt"
 	cmv1 "github.com/openshift-online/ocm-api-metamodel/tests/go/generated/clustersmgmt/v1"
+	sb "github.com/openshift-online/ocm-api-metamodel/tests/go/generated/statusboard"
 )
 
 var _ = Describe("Server", func() {
@@ -593,6 +594,10 @@ func (s *MyServer) Authorizations() az.Server {
 
 func (s *MyServer) ClustersMgmt() cm.Server {
 	return s.clustersMgmt
+}
+
+func (s *MyServer) StatusBoard() sb.Server {
+	return nil
 }
 
 // MyCMServer is the implementation of the clusters management server.

--- a/tests/model/status_board/v1/root_resource.model
+++ b/tests/model/status_board/v1/root_resource.model
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource Root {
+  locator Statuses {
+    target Statuses
+  }
+}

--- a/tests/model/status_board/v1/status_type.model
+++ b/tests/model/status_board/v1/status_type.model
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Definition of a Status Board status.
+class Status {
+  // Object creation timestamp.
+  CreatedAt Date
+
+  // Object modification timestamp.
+  UpdatedAt Date
+
+  // A status message for the given service.
+  Status String
+
+  // Miscellaneous metadata about the application.
+  Metadata Interface
+}

--- a/tests/model/status_board/v1/statuses_resource.model
+++ b/tests/model/status_board/v1/statuses_resource.model
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of statuses
+resource Statuses {
+  // Retrieves the list of statuses.
+  method List {
+    in out Page Integer = 1
+    in out Size Integer = 100
+    in CreatedAfter Date
+    in CreatedBefore Date
+    out Total Integer
+    out Items []Status
+  }
+}


### PR DESCRIPTION
Currently query parameters that are dates are formatted using the
default Go format, but they should be formatted using RFC3389 format.
This patch fixes that.