### PR TITLE
Release 0.0.50

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+## 0.0.50 Jan 25 2022
+
+- Fix format of date query parameters so that it is RFC3339.
+
 ## 0.0.49 Jan 6 2022
 
 This release doesn't include any change in functionality, it only adds to the

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.49"
+const Version = "0.0.50"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix format of date query parameters so that it is RFC3339.