### PR TITLE
Check for `io.EOF` before trying to parse response body

### DIFF
--- a/pkg/generators/golang/json_generator.go
+++ b/pkg/generators/golang/json_generator.go
@@ -551,7 +551,6 @@ func (g *JSONSupportGenerator) generateStructTypeSupport(typ *concepts.Type) err
 func (g *JSONSupportGenerator) generateStructTypeSource(typ *concepts.Type) {
 	g.buffer.Import("fmt", "")
 	g.buffer.Import("io", "")
-	g.buffer.Import("net/http", "")
 	g.buffer.Import("time", "")
 	g.buffer.Import("github.com/json-iterator/go", "jsoniter")
 	g.buffer.Import(g.packages.HelpersImport(), "")
@@ -634,9 +633,6 @@ func (g *JSONSupportGenerator) generateStructTypeSource(typ *concepts.Type) {
 		// {{ $unmarshalTypeFunc }} reads a value of the '{{ .Type.Name }}' type from the given
 		// source, which can be an slice of bytes, a string or a reader.
 		func {{ $unmarshalTypeFunc }}(source interface{}) (object *{{ $structName }}, err error) {
-			if source == http.NoBody {
-				return
-			}
 			iterator, err := helpers.NewIterator(source)
 			if err != nil {
 				return

--- a/tests/go/clients_test.go
+++ b/tests/go/clients_test.go
@@ -502,4 +502,29 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 	})
+
+	It("Accepts `204 No Content` with empty response body", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			RespondWith(http.StatusNoContent, ""),
+		)
+
+		// Create a transport that replaces the response body with an empty reader:
+		transport = &EmptyResponseBodyTransport{
+			wrapped: transport,
+		}
+
+		// Send the request:
+		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
+		body, err := cmv1.NewCluster().
+			Name("my-cluster").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		response, err := client.Add().
+			Body(body).
+			Send()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.Status()).To(Equal(http.StatusNoContent))
+		Expect(response.Body()).To(BeNil())
+	})
 })

--- a/tests/go/main_test.go
+++ b/tests/go/main_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package tests
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"testing"
 
@@ -54,5 +56,23 @@ func (t *Transport) RoundTrip(request *http.Request) (response *http.Response, e
 	request.URL.Host = t.server.Addr()
 	request.Header.Set("Content-type", "application/json")
 	response, err = t.wrapped.RoundTrip(request)
+	return
+}
+
+// EmptyResponseBodyTransport is an implementation of the RoundTripper interface that replaces the
+// response body with an empty reader different to `http.NoBody`. This is intended to test the
+// behaviour of the client when it receives this kind of response.
+type EmptyResponseBodyTransport struct {
+	wrapped http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *EmptyResponseBodyTransport) RoundTrip(request *http.Request) (response *http.Response,
+	err error) {
+	response, err = t.wrapped.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	response.Body = io.NopCloser(&bytes.Buffer{})
 	return
 }


### PR DESCRIPTION
Currently the clients always try to parse the HTTP response body, even
when it is empty. The `Unmarshal...` methods used for that compare the
reader to `http.NoBody` and return nil in that case. This isn't reliable
because transport wrappers may use a different type to indicate an empty
response body. To avoid that this patch replaces that check with a
buffered reader. This is used to peek the first byte of the response
body and then check if it results in `io.EOF`. This approach should work
regardless of the type of the response body.