### PR TITLE
Release 0.0.51

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+## 0.0.51 Feb 3 2022
+
+- Check for `io.EOF` before trying to parse response body.
+
 ## 0.0.50 Jan 25 2022
 
 - Fix format of date query parameters so that it is RFC3339.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.50"
+const Version = "0.0.51"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Check for `io.EOF` before trying to parse response body.