### PR TITLE
Add `@json` and `@http` annotations

### DIFF
--- a/pkg/http/binding_calculator.go
+++ b/pkg/http/binding_calculator.go
@@ -182,28 +182,48 @@ func (c *BindingCalculator) DefaultStatus(method *concepts.Method) string {
 
 // AttributeName returns the field name corresponding to the given model attribute.
 func (c *BindingCalculator) AttributeName(attribute *concepts.Attribute) string {
+	name := c.jsonName(attribute)
+	if name != "" {
+		return name
+	}
 	return attribute.Name().Snake()
 }
 
 // ParameterName returns the name of the field or query parameter corresponding to the given  model
 // method parameter.
 func (c *BindingCalculator) ParameterName(parameter *concepts.Parameter) string {
+	name := c.jsonName(parameter)
+	if name != "" {
+		return name
+	}
 	return parameter.Name().Snake()
 }
 
 // ServiceSegment calculates the URL segment corresponding to the given service.
 func (c *BindingCalculator) ServiceSegment(service *concepts.Service) string {
+	name := c.httpName(service)
+	if name != "" {
+		return name
+	}
 	return service.Name().Snake()
 }
 
 // VersionSegment calculates the URL segment corresponding to the given version.
 func (c *BindingCalculator) VersionSegment(version *concepts.Version) string {
+	name := c.httpName(version)
+	if name != "" {
+		return name
+	}
 	return version.Name().Snake()
 }
 
 // LocatorSegment calculates the URL segment corresponding to the given method.
 func (c *BindingCalculator) MethodSegment(method *concepts.Method) string {
 	if method.IsAction() {
+		name := c.httpName(method)
+		if name != "" {
+			return name
+		}
 		return method.Name().Snake()
 	}
 	return ""
@@ -211,10 +231,46 @@ func (c *BindingCalculator) MethodSegment(method *concepts.Method) string {
 
 // LocatorSegment calculates the URL segment corresponding to the given locator.
 func (c *BindingCalculator) LocatorSegment(locator *concepts.Locator) string {
+	name := c.httpName(locator)
+	if name != "" {
+		return name
+	}
 	return locator.Name().Snake()
 }
 
 // EnumValueName returns the name corresponding to a value of an enumerated type.
 func (c *BindingCalculator) EnumValueName(value *concepts.EnumValue) string {
+	name := c.jsonName(value)
+	if name != "" {
+		return name
+	}
 	return value.Name().Snake()
+}
+
+// httpName checks if the given concept has a `http` annotation. If it does then it returns the
+// value of the `name` parameter. If it doesn't, it returns an empty string.
+func (c *BindingCalculator) httpName(concept concepts.Annotated) string {
+	annotation := concept.GetAnnotation("http")
+	if annotation == nil {
+		return ""
+	}
+	name := annotation.FindParameter("name")
+	if name == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", name)
+}
+
+// jsonName checks if the given concept has a `json` annotation. If it does then it returns the
+// value of the `name` parameter. If it doesn't, it returns an empty string.
+func (c *BindingCalculator) jsonName(concept concepts.Annotated) string {
+	annotation := concept.GetAnnotation("json")
+	if annotation == nil {
+		return ""
+	}
+	name := annotation.FindParameter("name")
+	if name == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", name)
 }

--- a/tests/go/clients_test.go
+++ b/tests/go/clients_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Client", func() {
 			CombineHandlers(
 				VerifyRequest(
 					http.MethodPost,
-					"/api/clusters_mgmt/v1/register_cluster",
+					"/api/clusters_mgmt/v1/register",
 				),
 				VerifyJSON(`{
 					"subscription_id": "123",

--- a/tests/go/servers_test.go
+++ b/tests/go/servers_test.go
@@ -558,7 +558,7 @@ var _ = Describe("Server", func() {
 	It("Supports non REST method", func() {
 		request := httptest.NewRequest(
 			http.MethodPost,
-			"/api/clusters_mgmt/v1/register_cluster",
+			"/api/clusters_mgmt/v1/register",
 			strings.NewReader(`{
 				"subscription_id": "123",
 				"external_id": "456"

--- a/tests/go/unmarshal_test.go
+++ b/tests/go/unmarshal_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Unmarshal", func() {
 
 	It("Can read date", func() {
 		object, err := cmv1.UnmarshalCluster(`{
-			"creation_timestamp": "2019-07-12T17:12:57.019504Z"
+			"created_at": "2019-07-12T17:12:57.019504Z"
 		}`)
 		Expect(err).ToNot(HaveOccurred())
 		date := object.CreationTimestamp()

--- a/tests/model/clusters_mgmt/v1/cluster_type.model
+++ b/tests/model/clusters_mgmt/v1/cluster_type.model
@@ -50,6 +50,7 @@ class Cluster {
 
 	// Date and time when the cluster was initially created, using the
 	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	@json(name = "created_at")
 	CreationTimestamp Date
 
 	// Date and time when the cluster will be automatically deleted, using the format defined in

--- a/tests/model/clusters_mgmt/v1/root_resource.model
+++ b/tests/model/clusters_mgmt/v1/root_resource.model
@@ -16,6 +16,7 @@ limitations under the License.
 
 // Root of the tree of resources of the clusters management service.
 resource Root {
+	@http(name = "register")
 	method RegisterCluster {
 		in SubscriptionID String
 		in ExternalID String


### PR DESCRIPTION
The `@json` annotation is used to set an alternative name for attributes
and parameters in JSON representations. For example, if an attribute is
defined line this:

```
attribute CPUID string
```

The generated code will use `cpuid` in the JSON representation. This may
be incorrect if the intent was to use two separate words `CPU` and `ID`.
the annotation can be used to tell the code generator to use `cpu_id`
instead:

```
@json(name = "cpu_id")
attribute CPUID string
```

The `@http` annotation is similar, but intended for segments of URLs
corresponding to methods, locators and query parameters.