### PR TITLE
Add original text to name

### DIFF
--- a/pkg/names/name.go
+++ b/pkg/names/name.go
@@ -25,6 +25,7 @@ import (
 // case. The workds that form the name are stored separated, so there is no need to parse the name
 // each time that the workds are needed.
 type Name struct {
+	text  string
 	words []*Word
 }
 
@@ -36,8 +37,18 @@ func NewName(words ...*Word) *Name {
 	return name
 }
 
+// Text returns the text that was originally used to create this name.
+func (n *Name) Text() string {
+	return n.text
+}
+
+// SetText sets the text that was originally used to create this name.
+func (n *Name) SetText(text string) {
+	n.text = text
+}
+
 // Words returns a slice containing the words of the name. The returned slice is a copy of the
-// internal representation, to it is safe to modify after alling this function.
+// internal representation, to it is safe to modify after calling this function.
 func (n *Name) Words() []*Word {
 	words := make([]*Word, len(n.words))
 	copy(words, n.words)
@@ -106,7 +117,7 @@ func (n *Name) CapitalizedJoined(separator string) string {
 	return strings.Join(chunks, separator)
 }
 
-// StringType generates a string representing this name, consisting on the list of words of the name
+// String generates a string representing this name, consisting on the list of words of the name
 // separated by an underscore.
 func (n *Name) String() string {
 	texts := make([]string, len(n.words))

--- a/pkg/names/parser.go
+++ b/pkg/names/parser.go
@@ -33,7 +33,9 @@ func ParseUsingSeparator(text string, separator string) *Name {
 	for i, chunk := range chunks {
 		words[i] = NewWord(chunk)
 	}
-	return NewName(words...)
+	name := NewName(words...)
+	name.SetText(text)
+	return name
 }
 
 // ParseUsingCase separates the given text into words, using the case transitions as separators, and
@@ -124,7 +126,9 @@ func ParseUsingCase(text string) *Name {
 	}
 
 	// Create the name from the stored words:
-	return NewName(words...)
+	name := NewName(words...)
+	name.SetText(text)
+	return name
 }
 
 // parseWord converts the given text into a Word object assuming that it is a single word.


### PR DESCRIPTION
This patch adds to the `names.Name` type a new field to store the
original text that was used to create it.