### PR TITLE
adding Impersonate method for requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # OpenShift cluster manager API metamodel
 
-This project contains the code for the `ocm-metamode-tool` command line utility,
+This project contains the code for the `ocm-metamodel-tool` command line utility,
 which is used to generate code from the API model.

--- a/pkg/generators/golang/clients_generator.go
+++ b/pkg/generators/golang/clients_generator.go
@@ -802,6 +802,13 @@ func (g *ClientsGenerator) generateRequestSource(method *concepts.Method) {
 			return r
 		}
 
+		// Impersonate wraps requests on behalf of another user.
+		// Note: Services that do not support this feature may silently ignore this call. 
+		func (r *{{ $requestName }}) Impersonate(user string) *{{ $requestName }} {
+			helpers.AddImpersonationHeader(&r.header, user)
+			return r
+		}
+
 		{{ range $requestParameters }}
 			{{ $fieldName := fieldName . }}
 			{{ $setterName := setterName . }}

--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -193,6 +193,11 @@ func (g *HelpersGenerator) Run() error {
 			return result
 		}
 
+		const impersonateUserHeader = "Impersonate-User"
+		func AddImpersonationHeader(header *http.Header, user string) {
+			AddHeader(header, impersonateUserHeader, user)
+		}
+
 		// CopyValues copies a slice of strings.
 		func CopyValues(values []string) []string {
 			if values == nil {


### PR DESCRIPTION
This call enables clients with appropriate permissions to make requests
on behalf of a different user. It is important to note that not all
services support impersonation calls.