### PR TITLE
Check `v2` pull requests

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -20,6 +20,7 @@ on:
   pull_request:
     branches:
     - main
+    - v2
 
 jobs:
 


### PR DESCRIPTION
This patch changes the GitHub actions so that pull requests for the `v2`
branch are also checked.