### PR TITLE
Add `v2` suffix to package names

### DIFF
--- a/cmd/metamodel/check/cmd.go
+++ b/cmd/metamodel/check/cmd.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Cmd is the definition of the command:

--- a/cmd/metamodel/generate/cmd.go
+++ b/cmd/metamodel/generate/cmd.go
@@ -19,9 +19,9 @@ package generate
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/generate/docs"
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/generate/golang"
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/generate/openapi"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/generate/docs"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/generate/golang"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/generate/openapi"
 )
 
 // Cmd is the definition of the command:

--- a/cmd/metamodel/generate/docs/cmd.go
+++ b/cmd/metamodel/generate/docs/cmd.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators/docs"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators/docs"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Cmd is the definition of the command:

--- a/cmd/metamodel/generate/golang/cmd.go
+++ b/cmd/metamodel/generate/golang/cmd.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators/golang"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators/openapi"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators/golang"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators/openapi"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Cmd is the definition of the command:

--- a/cmd/metamodel/generate/openapi/cmd.go
+++ b/cmd/metamodel/generate/openapi/cmd.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators/openapi"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/language"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators/openapi"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/language"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Cmd is the definition of the command:

--- a/cmd/metamodel/main.go
+++ b/cmd/metamodel/main.go
@@ -24,9 +24,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/check"
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/generate"
-	"github.com/openshift-online/ocm-api-metamodel/cmd/metamodel/version"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/check"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/generate"
+	"github.com/openshift-online/ocm-api-metamodel/v2/cmd/metamodel/version"
 )
 
 // Root command:

--- a/cmd/metamodel/version/cmd.go
+++ b/cmd/metamodel/version/cmd.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/info"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/info"
 )
 
 var Cmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift-online/ocm-api-metamodel
+module github.com/openshift-online/ocm-api-metamodel/v2
 
 go 1.17
 

--- a/pkg/concepts/attribute.go
+++ b/pkg/concepts/attribute.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Attribute is the representation of an attribute of an structured type.

--- a/pkg/concepts/error.go
+++ b/pkg/concepts/error.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Error is the representation of a catagery of errors.

--- a/pkg/concepts/locator.go
+++ b/pkg/concepts/locator.go
@@ -17,7 +17,7 @@ limitations under the License.
 package concepts
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Locator represents a resource locator, the reference from a resource to another resource.

--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -19,8 +19,8 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
 )
 
 // Method represents a method of a resource.

--- a/pkg/concepts/model.go
+++ b/pkg/concepts/model.go
@@ -19,7 +19,7 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Model is the representation of the set of services, each with a set of versions.

--- a/pkg/concepts/named.go
+++ b/pkg/concepts/named.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package concepts
 
-import "github.com/openshift-online/ocm-api-metamodel/pkg/names"
+import "github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 
 // namedSupport is an implementation of the names.Named interface intended to be embeded in other
 // types that need to implement that interface.

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -17,8 +17,8 @@ limitations under the License.
 package concepts
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
 )
 
 // Parameter represents a parameter of a method.

--- a/pkg/concepts/resource.go
+++ b/pkg/concepts/resource.go
@@ -19,7 +19,7 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Resource represents an API resource.

--- a/pkg/concepts/service.go
+++ b/pkg/concepts/service.go
@@ -19,7 +19,7 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Service is the representation of service, containing potentiall mutiple versions, for example the

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -19,7 +19,7 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // TypeKind specifies the kind of a type. It can be scalar, enum, struct, list or class.

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -19,8 +19,8 @@ package concepts
 import (
 	"sort"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
 )
 
 // Version is the representation of a version of a service.

--- a/pkg/generators/docs/docs_generator.go
+++ b/pkg/generators/docs/docs_generator.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/markdown"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/markdown"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // DocsGeneratorBuilder is an object used to configure and build the builders generator. Don't

--- a/pkg/generators/golang/annotations.go
+++ b/pkg/generators/golang/annotations.go
@@ -19,7 +19,7 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
 )
 
 // goName checks if the given concept as a `go` annotation. If it has it then it returns the value

--- a/pkg/generators/golang/buffer.go
+++ b/pkg/generators/golang/buffer.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // BufferBuilder is used to create a new Go buffer. Don't create it directly, use the

--- a/pkg/generators/golang/builders_generator.go
+++ b/pkg/generators/golang/builders_generator.go
@@ -19,10 +19,10 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // BuildersGeneratorBuilder is an object used to configure and build the builders generator. Don't

--- a/pkg/generators/golang/clients_generator.go
+++ b/pkg/generators/golang/clients_generator.go
@@ -19,11 +19,11 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // ClientsGeneratorBuilder is an object used to configure and build a client generator. Don't create

--- a/pkg/generators/golang/errors_generator.go
+++ b/pkg/generators/golang/errors_generator.go
@@ -19,10 +19,10 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // ErrorsGeneratorBuilder is an object used to configure and build an errors generator. Don't create
@@ -176,7 +176,7 @@ func (g *ErrorsGenerator) generateCommonErrors() error {
 	g.buffer.Import("io", "")
 	g.buffer.Import("strings", "")
 	g.buffer.Import("github.com/golang/glog", "")
-	g.buffer.Import("github.com/openshift-online/ocm-api-metamodel/pkg/runtime", "")
+	g.buffer.Import("github.com/openshift-online/ocm-api-metamodel/v2/pkg/runtime", "")
 	g.buffer.Import(g.packages.HelpersImport(), "")
 	g.buffer.Emit(`
 		// Error kind is the name of the type used to represent errors.

--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -19,9 +19,9 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // HelpersGeneratorBuilder is an object used to configure and build a helpers generator. Don't

--- a/pkg/generators/golang/json_generator.go
+++ b/pkg/generators/golang/json_generator.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // JSONSupportGeneratorBuilder is an object used to configure and build the JSON support generator.

--- a/pkg/generators/golang/metrics_generator.go
+++ b/pkg/generators/golang/metrics_generator.go
@@ -21,11 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // MetricsSupportGeneratorBuilder is an object used to configure and build the Metrics support

--- a/pkg/generators/golang/names_calculator.go
+++ b/pkg/generators/golang/names_calculator.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // NamesCalculatorBuilder is an object used to configure and build the Go names calculators. Don't

--- a/pkg/generators/golang/openapi_generator.go
+++ b/pkg/generators/golang/openapi_generator.go
@@ -25,10 +25,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/generators/openapi"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/generators/openapi"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // OpenAPIGeneratorBuilder is an object used to configure and build a OpenAPI specification

--- a/pkg/generators/golang/packages_calculator.go
+++ b/pkg/generators/golang/packages_calculator.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // PackagesCalculatorBuilder is an object used to configure and build the Go packages calculators.

--- a/pkg/generators/golang/types_calculator.go
+++ b/pkg/generators/golang/types_calculator.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // TypesCalculatorBuilder is an object used to configure and build the Go type calculators. Don't

--- a/pkg/generators/golang/types_generator.go
+++ b/pkg/generators/golang/types_generator.go
@@ -19,11 +19,11 @@ package golang
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // TypesGeneratorBuilder is an object used to configure and build the types generator. Don't create

--- a/pkg/generators/openapi/buffer.go
+++ b/pkg/generators/openapi/buffer.go
@@ -24,7 +24,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // BufferBuilder is used to create a new OpenAPI buffer. Don't create it directly, use the

--- a/pkg/generators/openapi/names_calculator.go
+++ b/pkg/generators/openapi/names_calculator.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // NamesCalculatorBuilder is an object used to configure and build the OpenAPI names calculators.

--- a/pkg/generators/openapi/openapi_generator.go
+++ b/pkg/generators/openapi/openapi_generator.go
@@ -22,9 +22,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/http"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/http"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // OpenAPIGeneratorBuilder is an object used to configure and build the OpenAPI specifications

--- a/pkg/http/annotations.go
+++ b/pkg/http/annotations.go
@@ -19,7 +19,7 @@ package http
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
 )
 
 // httpName checks if the given concept has a `http` annotation. If it does then it returns the

--- a/pkg/http/binding_calculator.go
+++ b/pkg/http/binding_calculator.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // BindingCalculatorBuilder is an object used to configure and build the HTTP bindings calculator.

--- a/pkg/language/ModelParser.g4
+++ b/pkg/language/ModelParser.g4
@@ -23,8 +23,8 @@ options {
 
 @header {
   import (
-    "github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-    "github.com/openshift-online/ocm-api-metamodel/pkg/names"
+    "github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+    "github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
   )
 }
 

--- a/pkg/language/annotations_test.go
+++ b/pkg/language/annotations_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package language
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -19,9 +19,9 @@ limitations under the License.
 package language
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
 )
 
 func (r *Reader) checkModel() {

--- a/pkg/language/errors.go
+++ b/pkg/language/errors.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // ErrorListenerBuilder is used to build error listeners.

--- a/pkg/language/main_test.go
+++ b/pkg/language/main_test.go
@@ -24,8 +24,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 func TestLanguage(t *testing.T) {

--- a/pkg/language/model_parser.go
+++ b/pkg/language/model_parser.go
@@ -10,8 +10,8 @@ import (
 )
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Suppress unused import errors

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/nomenclator"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/nomenclator"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Reader is used to read a model from a set of files. Don't create objects of this type directly,

--- a/pkg/language/writer.go
+++ b/pkg/language/writer.go
@@ -22,8 +22,8 @@ package language
 import (
 	"fmt"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // Writer is used to write a model to a set of files. Don't create objects of this type directly,

--- a/pkg/markdown/buffer.go
+++ b/pkg/markdown/buffer.go
@@ -26,7 +26,7 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // BufferBuilder is used to create a new Markdown buffer. Don't create it directly, use the

--- a/pkg/markdown/names_calculator.go
+++ b/pkg/markdown/names_calculator.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/reporter"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/reporter"
 )
 
 // NamesCalculatorBuilder is an object used to configure and build the Markdown names calculators.

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nomenclator
 
 import (
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 var (

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift-online/ocm-api-metamodel/pkg/concepts"
-	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/concepts"
+	"github.com/openshift-online/ocm-api-metamodel/v2/pkg/names"
 )
 
 // Builder contains the data and logic needed to create a new reporter. Don't create instances of


### PR DESCRIPTION
This patch adds the `v2` suffix to the package names.