### PR TITLE
Remove send without context

### DIFF
--- a/pkg/generators/golang/clients_generator.go
+++ b/pkg/generators/golang/clients_generator.go
@@ -342,15 +342,7 @@ func (g *ClientsGenerator) generateVersionMetadataClientSource(version *concepts
 		}
 
 		// Send sends the metadata request, waits for the response, and returns it.
-		//
-		// This is a potentially lengthy operation, as it requires network communication.
-		// Consider using a context and the SendContext method.
-		func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-			return r.SendContext(context.Background())
-		}
-
-		// SendContext sends the metadata request, waits for the response, and returns it.
-		func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+		func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 			query := helpers.CopyQuery(r.query)
 			header := helpers.CopyHeader(r.header)
 			uri := &url.URL{
@@ -656,13 +648,13 @@ func (g *ClientsGenerator) generatePollMethodSource(resource *concepts.Resource,
 			return r
 		}
 
-		// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+		// Start starts the polling loop. Responses will be considered successful if the status is one of
 		// the values specified with the Status method and if all the predicates specified with the Predicate
 		// method return nil.
 		//
 		// The context must have a timeout or deadline, otherwise this method will immediately return an error.
-		func (r *{{ $requestName }}) StartContext(ctx context.Context) (response *{{ $responseName }}, err error) {
-			result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+		func (r *{{ $requestName }}) Start(ctx context.Context) (response *{{ $responseName }}, err error) {
+			result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 			if result != nil {
 				response = &{{ $responseName }}{
 					response: result.(*{{ $methodResponseName }}),
@@ -674,7 +666,7 @@ func (g *ClientsGenerator) generatePollMethodSource(resource *concepts.Resource,
 		// task adapts the types of the request/response types so that they can be used with the generic
 		// polling function from the helpers package.
 		func (r *{{ $requestName }}) task(ctx context.Context) (status int, result interface{}, err error) {
-			response, err := r.request.SendContext(ctx)
+			response, err := r.request.Send(ctx)
 			if response != nil {
 				status = response.Status()
 				result = response
@@ -828,15 +820,7 @@ func (g *ClientsGenerator) generateRequestSource(method *concepts.Method) {
 		{{ end }}
 
 		// Send sends this request, waits for the response, and returns it.
-		//
-		// This is a potentially lengthy operation, as it requires network communication.
-		// Consider using a context and the SendContext method.
-		func (r *{{ $requestName }}) Send() (result *{{ $responseName }}, err error) {
-			return r.SendContext(context.Background())
-		}
-
-		// SendContext sends this request, waits for the response, and returns it.
-		func (r *{{ $requestName }}) SendContext(ctx context.Context) (result *{{ $responseName }}, err error) {
+		func (r *{{ $requestName }}) Send(ctx context.Context) (result *{{ $responseName }}, err error) {
 			query := helpers.CopyQuery(r.query)
 			{{ range $requestQueryParameters }}
 				{{ $fieldName := fieldName . }}

--- a/pkg/generators/golang/helpers_generator.go
+++ b/pkg/generators/golang/helpers_generator.go
@@ -219,9 +219,9 @@ func (g *HelpersGenerator) Run() error {
 			return strings.Split(path, "/")
 		}
 
-		// PollContext repeatedly executes a task till it returns one of the given statuses and till the result
+		// Poll repeatedly executes a task till it returns one of the given statuses and till the result
 		// satisfies all the given predicates.
-		func PollContext(
+		func Poll(
 			ctx context.Context,
 			interval time.Duration,
 			statuses []int,

--- a/tests/go/clients_test.go
+++ b/tests/go/clients_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -33,10 +34,12 @@ import (
 )
 
 var _ = Describe("Client", func() {
+	var ctx context.Context
 	var server *Server
 	var transport http.RoundTripper
 
 	BeforeEach(func() {
+		ctx = context.Background()
 		server = NewServer()
 		transport = NewTransport(server)
 	})
@@ -50,7 +53,7 @@ var _ = Describe("Client", func() {
 			"auths": {}
 		}`))
 		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
-		response, err := client.AccessToken().Send()
+		response, err := client.AccessToken().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		auths := response.Map()
@@ -67,7 +70,7 @@ var _ = Describe("Client", func() {
 			}
 		}`))
 		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
-		response, err := client.AccessToken().Send()
+		response, err := client.AccessToken().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		auths := response.Map()
@@ -92,7 +95,7 @@ var _ = Describe("Client", func() {
 			}
 		}`))
 		client := amv1.NewClient(transport, "/api/accounts_mgmt/v1")
-		response, err := client.AccessToken().Send()
+		response, err := client.AccessToken().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		auths := response.Map()
@@ -112,7 +115,7 @@ var _ = Describe("Client", func() {
 			"server_version": "123"
 		}`))
 		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1")
-		response, err := client.Get().Send()
+		response, err := client.Get().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		body := response.Body()
@@ -160,7 +163,7 @@ var _ = Describe("Client", func() {
 		client := cmv1.NewClient(transport, "/api/clusters_mgmt/v1")
 		response, err := client.RegisterDisconnected().
 			Cluster(cluster).
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -202,7 +205,7 @@ var _ = Describe("Client", func() {
 		response, err := client.RegisterCluster().
 			SubscriptionID("123").
 			ExternalID("456").
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -228,7 +231,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
-		response, err := client.List().Send()
+		response, err := client.List().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -256,7 +259,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
-		response, err := client.List().Send()
+		response, err := client.List().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -290,7 +293,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
-		response, err := client.List().Send()
+		response, err := client.List().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -335,7 +338,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
-		response, err := client.List().Send()
+		response, err := client.List().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -375,7 +378,7 @@ var _ = Describe("Client", func() {
 		response, err := client.List().
 			Page(123).
 			Size(456).
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 	})
@@ -402,7 +405,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClustersClient(transport, "/api/clusters_mgmt/v1/clusters")
-		response, err := client.List().Send()
+		response, err := client.List().Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -425,7 +428,7 @@ var _ = Describe("Client", func() {
 
 			// Send the request:
 			client := cmv1.NewClusterClient(transport, "")
-			_, err := client.Get().Parameter("my", value).Send()
+			_, err := client.Get().Parameter("my", value).Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		},
 		Entry("True", true, "true"),
@@ -469,7 +472,7 @@ var _ = Describe("Client", func() {
 
 		// Send the request:
 		client := cmv1.NewClusterClient(transport, "/api/clusters_mgmt/v1/clusters/123")
-		_, err := client.Delete().Send()
+		_, err := client.Delete().Send(ctx)
 		Expect(err).To(HaveOccurred())
 
 		// Verify the error:
@@ -498,7 +501,7 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		response, err := client.List().
 			CreatedAfter(date).
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 	})
@@ -522,7 +525,7 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		response, err := client.Add().
 			Body(body).
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response.Status()).To(Equal(http.StatusNoContent))
 		Expect(response.Body()).To(BeNil())

--- a/tests/go/poll_test.go
+++ b/tests/go/poll_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Poll", func() {
 		ctx := context.Background()
 		_, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -56,7 +56,7 @@ var _ = Describe("Poll", func() {
 		client := cmv1.NewClusterClient(transport, "")
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(0).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -74,7 +74,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		_, err := client.Poll().
 			Interval(-1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -89,7 +89,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		status := response.Status()
@@ -113,7 +113,7 @@ var _ = Describe("Poll", func() {
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
 			Status(http.StatusNotFound).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 		status := response.Status()
 		Expect(status).To(Equal(http.StatusNotFound))
@@ -142,7 +142,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		status := response.Status()
 		Expect(status).To(Equal(http.StatusOK))
@@ -170,7 +170,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		status := response.Status()
 		Expect(status).To(Equal(http.StatusOK))
@@ -196,7 +196,7 @@ var _ = Describe("Poll", func() {
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		response, err := client.Poll().
 			Interval(1 * time.Millisecond).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).To(HaveOccurred())
 		Expect(ctx.Err()).ToNot(BeNil())
 		Expect(response).To(BeNil())
@@ -217,7 +217,7 @@ var _ = Describe("Poll", func() {
 			Predicate(func(response *cmv1.ClusterGetResponse) bool {
 				return response.Body().State() == cmv1.ClusterStateReady
 			}).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		status := response.Status()
 		Expect(status).To(Equal(http.StatusOK))
@@ -250,7 +250,7 @@ var _ = Describe("Poll", func() {
 			Predicate(func(response *cmv1.ClusterGetResponse) bool {
 				return response.Body().State() == cmv1.ClusterStateReady
 			}).
-			StartContext(ctx)
+			Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		status := response.Status()
 		Expect(status).To(Equal(http.StatusOK))


### PR DESCRIPTION
This patch removes the code that generates the methods that send
requests without a context. It will no mandatory to use the `Send`
method with a context, and the `SendContext` method is removed.