### PR TITLE
Release 0.0.53

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,11 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
-## 0.0.52 Mar 8 2020
+## 0.0.53 Apr 1 2022
+
+- Don't consider `Status` and `Error` built-in request parameters.
+
+## 0.0.52 Mar 8 2022
 
 - Add support for annotations.
 - Add `@json` and `@http` annotations.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.52"
+const Version = "0.0.53"


### PR DESCRIPTION
The more relevant changes in the new release are the following:

- Don't consider `Status` and `Error` built-in request parameters.