### PR TITLE
[SDB-3474] Generated openapi json has the following problems

### DIFF
--- a/pkg/generators/openapi/openapi_generator.go
+++ b/pkg/generators/openapi/openapi_generator.go
@@ -372,6 +372,7 @@ func (g *OpenAPIGenerator) generatePathParameter(locator *concepts.Locator) {
 	g.buffer.StartObject("schema")
 	g.buffer.Field("type", "string")
 	g.buffer.EndObject()
+	g.buffer.Field("required", true)
 	g.buffer.EndObject()
 }
 
@@ -630,7 +631,7 @@ func (g *OpenAPIGenerator) generateErrorSchema() {
 	g.buffer.StartObject("details")
 	g.generateDescription("Extra information about the error.")
 	g.buffer.Field("type", "object")
-	g.buffer.Field("additionalProperties", "true")
+	g.buffer.Field("additionalProperties", true)
 	g.buffer.EndObject()
 
 	g.buffer.EndObject()


### PR DESCRIPTION
1.
"details": {
"description": "Extra information about the error.",
"type": "object",
"additionalProperties": "true"
}
but according to openapi scheme it must be
"additionalProperties": true
which is default anyway. This is from openapi spec:
additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema. Consistent with JSON Schema, additionalProperties defaults to true.
 
2.
invalid paths: invalid path /api/clusters_mgmt/v1/addons/{addon_id}: invalid operation DELETE: path parameter "addon_id" must be required