### PR TITLE
Release 0.0.58

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the
 API metamodel.
 
+## 0.0.58 May 18 2023
+
+- Honor `@json` annotation in OpenAPI generation.
+
 ## 0.0.57 Jan 31 2023
 
 - additionalProperties: is boolean

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.57"
+const Version = "0.0.58"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Honor `@json` annotation in OpenAPI generator.