### PR TITLE
Honor `@http` annotation for query parameters

### DIFF
--- a/pkg/generators/golang/clients_generator.go
+++ b/pkg/generators/golang/clients_generator.go
@@ -452,7 +452,7 @@ func (g *ClientsGenerator) generateResourceClient(resource *concepts.Resource) e
 		Function("locatorSegment", g.binding.LocatorSegment).
 		Function("methodName", g.methodName).
 		Function("methodSegment", g.binding.MethodSegment).
-		Function("parameterName", g.binding.ParameterName).
+		Function("parameterName", g.binding.QueryParameterName).
 		Function("pollRequestName", g.pollRequestName).
 		Function("pollResponseName", g.pollResponseName).
 		Function("readResponseFunc", g.readResponseFunc).

--- a/pkg/generators/golang/json_generator.go
+++ b/pkg/generators/golang/json_generator.go
@@ -809,7 +809,7 @@ func (g *JSONSupportGenerator) generateResourceSupport(resource *concepts.Resour
 		Function("generateWriteValue", g.generateWriteValue).
 		Function("marshalTypeFunc", g.marshalTypeFunc).
 		Function("parameterFieldName", g.parameterFieldName).
-		Function("parameterFieldTag", g.binding.ParameterName).
+		Function("parameterQueryName", g.binding.QueryParameterName).
 		Function("readResponseFunc", g.readResponseFunc).
 		Function("readTypeFunc", g.readTypeFunc).
 		Function("requestBodyParameters", g.binding.RequestBodyParameters).
@@ -1216,11 +1216,11 @@ func (g *JSONSupportGenerator) generateReadQueryParameter(parameter *concepts.Pa
 		return ""
 	}
 	field := g.parameterFieldName(parameter)
-	tag := g.binding.ParameterName(parameter)
+	tag := g.binding.QueryParameterName(parameter)
 	kind := typ.Name().Camel()
 	return g.buffer.Eval(`
 		{{ $field := parameterFieldName .Parameter }}
-		{{ $tag := parameterFieldTag .Parameter }}
+		{{ $tag := parameterQueryName .Parameter }}
 		{{ $kind := .Parameter.Type.Name.Camel }}
 
 		request.{{ $field }}, err = helpers.Parse{{ $kind }}(query, "{{ $tag }}")
@@ -1243,7 +1243,7 @@ func (g *JSONSupportGenerator) generateReadQueryParameter(parameter *concepts.Pa
 func (g *JSONSupportGenerator) generateReadBodyParameter(object string, parameter *concepts.
 	Parameter) string {
 	field := g.parameterFieldName(parameter)
-	tag := g.binding.ParameterName(parameter)
+	tag := g.binding.BodyParameterName(parameter)
 	typ := parameter.Type()
 	return g.buffer.Eval(`
 		case "{{ .Tag }}":
@@ -1336,7 +1336,7 @@ func (g *JSONSupportGenerator) generateWriteBodyParameter(object string,
 	parameter *concepts.Parameter) string {
 	typ := parameter.Type()
 	field := g.parameterFieldName(parameter)
-	tag := g.binding.ParameterName(parameter)
+	tag := g.binding.BodyParameterName(parameter)
 	var value string
 	if typ.IsScalar() && !typ.IsInterface() {
 		value = g.buffer.Eval(

--- a/pkg/generators/openapi/openapi_generator.go
+++ b/pkg/generators/openapi/openapi_generator.go
@@ -378,7 +378,7 @@ func (g *OpenAPIGenerator) generatePathParameter(locator *concepts.Locator) {
 
 func (g *OpenAPIGenerator) generateQueryParameter(parameter *concepts.Parameter) {
 	g.buffer.StartObject()
-	g.buffer.Field("name", g.binding.ParameterName(parameter))
+	g.buffer.Field("name", g.binding.QueryParameterName(parameter))
 	g.generateDescription(parameter.Doc())
 	g.buffer.Field("in", "query")
 	g.buffer.StartObject("schema")

--- a/pkg/http/binding_calculator.go
+++ b/pkg/http/binding_calculator.go
@@ -190,9 +190,27 @@ func (c *BindingCalculator) AttributeName(attribute *concepts.Attribute) string 
 	return name
 }
 
-// ParameterName returns the name of the field or query parameter corresponding to the given  model
+// QueryParameterName returns the name of the query parameter corresponding to the given model
 // method parameter.
-func (c *BindingCalculator) ParameterName(parameter *concepts.Parameter) string {
+func (c *BindingCalculator) QueryParameterName(parameter *concepts.Parameter) string {
+	name := annotations.HTTPName(parameter)
+	if name == "" {
+		// We check also the JSON annotation here for "bug compatibility". In the past we
+		// used to check only the JSON name, but that is incorrect because this is about
+		// HTTP query parameters, not JSON field names. But some models (the 'dryRun'
+		// parameter of the accounts management service, for example) are already using that
+		// bug as it was a feature.
+		name = annotations.JSONName(parameter)
+		if name == "" {
+			name = parameter.Name().Snake()
+		}
+	}
+	return name
+}
+
+// BodyParameterName returns the name of the body field corresponding to the given  model method
+// parameter.
+func (c *BindingCalculator) BodyParameterName(parameter *concepts.Parameter) string {
 	name := annotations.JSONName(parameter)
 	if name == "" {
 		name = parameter.Name().Snake()

--- a/tests/model/clusters_mgmt/v1/clusters_resource.model
+++ b/tests/model/clusters_mgmt/v1/clusters_resource.model
@@ -67,8 +67,19 @@ resource Clusters {
 	//
 	// See the `register_cluster` method for adding an existing cluster.
 	method Add {
+                @http(name = "dryRun")
+                in DryRun Boolean
+
 		// Description of the cluster.
 		in out Body Cluster
+	}
+
+	// This is used in tests to verify that annotations are interpreted correctly.
+	@http(name = "my_test")
+	method TestAnnotations {
+                @json(name = "my_json") // Should be honored.
+                @http(name = "my_http") // Should be ignored.
+                in out My Boolean
 	}
 
 	// Returns a reference to the service that manages an specific cluster.


### PR DESCRIPTION
Currently the `@http` annotation is ignored for query parameters. We are using `@json` instead. That is a bug, and this patch fixes it.