### PR TITLE
Add support for 'ref' annotation

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -63,3 +63,17 @@ func GoName(concept concepts.Annotated) string {
 	}
 	return fmt.Sprintf("%s", name)
 }
+
+// Reference checks if the given concept has a `reference` annotation. If it has it then it returns the value
+// of the `path` parameter. It returns an empty string if there is no such annotation or parameter.
+func ReferencePath(concept concepts.Annotated) string {
+	annotation := concept.GetAnnotation("ref")
+	if annotation == nil {
+		return ""
+	}
+	name := annotation.FindParameter("path")
+	if name == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", name)
+}

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -164,6 +164,14 @@ func (t *Type) IsScalar() bool {
 	return t.kind == ScalarType || t.kind == EnumType || t.kind == InterfaceType
 }
 
+func (t *Type) IsBasicType() bool {
+	if t == nil {
+		return false
+	}
+
+	return t.kind == ScalarType
+}
+
 // IsStruct returns true iff this type is an struct type. Note that class types are also considered
 // struct types.
 func (t *Type) IsStruct() bool {

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -17,7 +17,6 @@ limitations under the License.
 package concepts
 
 import (
-	"log"
 	"sort"
 
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
@@ -183,19 +182,6 @@ func (t *Type) AddAttribute(attribute *Attribute) {
 		t.attributes = append(t.attributes, attribute)
 		sort.Sort(t.attributes)
 		attribute.SetOwner(t)
-	}
-}
-
-// Remove attribute removes an attribute with a given name.
-func (t *Type) RemoveAttribute(name *names.Name) {
-	if name == nil {
-		return
-	}
-	for i, attribute := range t.attributes {
-		if attribute.Name().Equals(name) {
-			log.Printf("---------- Deleting attribute %s", name.String())
-			t.attributes = append(t.attributes[:i], t.attributes[i+1:]...)
-		}
 	}
 }
 

--- a/pkg/concepts/type.go
+++ b/pkg/concepts/type.go
@@ -17,6 +17,7 @@ limitations under the License.
 package concepts
 
 import (
+	"log"
 	"sort"
 
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
@@ -182,6 +183,19 @@ func (t *Type) AddAttribute(attribute *Attribute) {
 		t.attributes = append(t.attributes, attribute)
 		sort.Sort(t.attributes)
 		attribute.SetOwner(t)
+	}
+}
+
+// Remove attribute removes an attribute with a given name.
+func (t *Type) RemoveAttribute(name *names.Name) {
+	if name == nil {
+		return
+	}
+	for i, attribute := range t.attributes {
+		if attribute.Name().Equals(name) {
+			log.Printf("---------- Deleting attribute %s", name.String())
+			t.attributes = append(t.attributes[:i], t.attributes[i+1:]...)
+		}
 	}
 }
 

--- a/pkg/concepts/version.go
+++ b/pkg/concepts/version.go
@@ -106,6 +106,15 @@ func (v *Version) AddType(typ *Type) {
 	}
 }
 
+// AddTypeWithoutOwner adds the given type to the version *without* changing
+// its owner. This is crucial when were adding references to other types from different
+// versions.
+func (v *Version) AddTypeWithoutOwner(typ *Type) {
+	if typ != nil {
+		v.types[typ.Name().String()] = typ
+	}
+}
+
 // AddTypes adds the given types to the version.
 func (v *Version) AddTypes(types []*Type) {
 	for _, typ := range types {

--- a/pkg/generators/golang/types_calculator.go
+++ b/pkg/generators/golang/types_calculator.go
@@ -143,7 +143,7 @@ func (c *TypesCalculator) StructReference(typ *concepts.Type) *TypeReference {
 			ref.name = c.names.Public(element.Name())
 		}
 		ref.name += "List"
-		ref.text = ref.name
+		ref.text = fmt.Sprintf("%s.%s", ref.selector, ref.name)
 	case typ.IsStruct():
 		ref = &TypeReference{}
 		ref.imprt, ref.selector = c.Package(typ)
@@ -151,7 +151,7 @@ func (c *TypesCalculator) StructReference(typ *concepts.Type) *TypeReference {
 		if ref.name == "" {
 			ref.name = c.names.Public(typ.Name())
 		}
-		ref.text = ref.name
+		ref.text = fmt.Sprintf("%s.%s", ref.selector, ref.name)
 	default:
 		c.reporter.Errorf(
 			"Don't know how to calculate struct type reference for type '%s'",
@@ -213,7 +213,7 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 			ref.text = fmt.Sprintf("[]%s", ref.text)
 		case element.IsStruct():
 			ref = c.ValueReference(element)
-			ref.text = fmt.Sprintf("[]*%s", ref.text)
+			ref.text = fmt.Sprintf("[]*%s.%s", ref.selector, ref.text)
 		}
 	case typ.IsMap():
 		element := typ.Element()
@@ -223,7 +223,7 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 			ref.text = fmt.Sprintf("map[string]%s", ref.text)
 		case element.IsStruct():
 			ref = c.ValueReference(element)
-			ref.text = fmt.Sprintf("map[string]*%s", ref.text)
+			ref.text = fmt.Sprintf("map[string]*%s.%s", ref.selector, ref.text)
 		}
 	case typ.IsStruct():
 		ref = &TypeReference{}
@@ -248,9 +248,13 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 // the nil value.
 func (c *TypesCalculator) NullableReference(typ *concepts.Type) *TypeReference {
 	switch {
-	case (typ.IsScalar() && !typ.IsInterface()) || typ.IsStruct():
+	case (typ.IsScalar() && !typ.IsInterface()):
 		ref := c.ValueReference(typ)
 		ref.text = fmt.Sprintf("*%s", ref.text)
+		return ref
+	case typ.IsStruct():
+		ref := c.ValueReference(typ)
+		ref.text = fmt.Sprintf("*%s.%s", ref.selector, ref.name)
 		return ref
 	default:
 		return c.ValueReference(typ)

--- a/pkg/generators/golang/types_calculator.go
+++ b/pkg/generators/golang/types_calculator.go
@@ -239,6 +239,7 @@ func (c *TypesCalculator) ValueReference(typ *concepts.Type) *TypeReference {
 			"Don't know how to calculate value reference for type '%s'",
 			typ,
 		)
+
 		ref = &TypeReference{}
 	}
 	return ref

--- a/pkg/generators/golang/types_generator.go
+++ b/pkg/generators/golang/types_generator.go
@@ -505,6 +505,32 @@ func (g *TypesGenerator) generateStructTypeSource(typ *concepts.Type) {
 			return len(l.items)
 		}
 
+		// Items sets the items of the list.
+		func (l *{{ $listName }}) SetLink(link bool) {
+			l.link = link
+			return
+		}
+
+		// Items sets the items of the list.
+		func (l *{{ $listName }}) SetHREF(href string) {
+			l.href = href
+			return
+		}
+
+		// Items sets the items of the list.
+		func (l *{{ $listName }}) SetItems(items []*{{ $objectName }}) {
+			l.items = items
+			return
+		}
+
+		// Items returns the items of the list.
+		func (l *{{ $listName }}) Items() []*{{ $objectName }} {
+			if l == nil {
+				return nil
+			}
+			return l.items
+		}
+
 		// Empty returns true if the list is empty.
 		func (l *{{ $listName }}) Empty() bool {
 			return l == nil || len(l.items) == 0

--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -520,8 +520,8 @@ func (r *Reader) checkParameter(parameter *concepts.Parameter) {
 		}
 		if typ != nil && typ != parameter.Type() {
 			r.reporter.Errorf(
-				"Type of default value of parameter '%s' should be '%s'",
-				parameter, parameter.Type(),
+				"Type of default value of parameter '%s' should be '%s', instead it was %s",
+				parameter, parameter.Type(), typ.Name().String(),
 			)
 		}
 	}

--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -520,8 +520,8 @@ func (r *Reader) checkParameter(parameter *concepts.Parameter) {
 		}
 		if typ != nil && typ != parameter.Type() {
 			r.reporter.Errorf(
-				"Type of default value of parameter '%s' should be '%s', instead it was %s",
-				parameter, parameter.Type(), typ.Name().String(),
+				"Type of default value of parameter '%s' should be '%s'",
+				parameter, parameter.Type(),
 			)
 		}
 	}

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -486,6 +486,9 @@ func (r *Reader) recursivelyAddTypeToVersion(currType *concepts.Type,
 	}
 	for _, attribute := range referencedType.Attributes() {
 		if attribute.Link() {
+			// We need to check if the type was previously introduced
+			// in that case we would simply changes the owner of the attribue
+			// as we had already compiled it in this version.
 			if attribute.Type().IsList() {
 				if r.version.FindType(attribute.Type().Element().Name()) == nil {
 					r.version.AddTypeWithoutOwner(attribute.Type())

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -796,67 +796,6 @@ func (r *Reader) ExitLocatorDecl(ctx *LocatorDeclContext) {
 	// Add the annotations:
 	r.addAnnotations(locator, ctx.GetAnnotations())
 
-	if path := annotations.ReferencePath(locator); path != "" {
-		if len(r.inputs) > 1 {
-			panic("refernced service with multiple inputs in undefined")
-		}
-
-		if r.service.Versions().Len() > 1 {
-			panic("cannot infer which version to add reference with multiple versions")
-		}
-
-		input := r.inputs[0]
-		currVersion := r.service.Versions()[0]
-		path = strings.TrimPrefix(path, "/")
-		components := strings.Split(path, "/")
-		referencedServiceName := components[0]
-		referencedVersion := components[1]
-		referencedLocator := components[2]
-
-		// Create an ad-hoc reader and model for the specific referenced service.
-		refReader := NewReader().
-			Reporter(r.reporter)
-		refReader.model = concepts.NewModel()
-
-		// Initialize the indexes of undefined concepts:
-		refReader.undefinedTypes = make(map[string]*concepts.Type)
-		refReader.undefinedResources = make(map[string]*concepts.Resource)
-		refReader.undefinedErrors = make(map[string]*concepts.Error)
-
-		// load the ad-hoc service and version referenced and find the correct locator.
-		refReader.loadService(fmt.Sprintf("%s/%s", input, referencedServiceName))
-		refVersion := refReader.service.FindVersion(names.ParseUsingSeparator(referencedVersion, "_"))
-		for _, currLocator := range refVersion.Root().Locators() {
-			if strings.Compare(currLocator.Name().String(), referencedLocator) == 0 {
-				for _, resource := range refVersion.Resources() {
-					if resource.IsRoot() {
-						// We do not need to copy over the root resource.
-						continue
-					}
-
-					// Add any underlying resource to the current version.
-					currVersion.AddResource(resource)
-					// Add underlying methods.
-					for _, method := range resource.Methods() {
-						currVersion.
-							FindResource(resource.Name()).
-							AddMethod(method)
-					}
-
-					// Remove any undefined resources as
-					// This is a no-op except for the reference target added
-					// by the locator as the compiler will attempt to compile it
-					r.removeUndefinedResource(resource)
-				}
-
-				currVersion.AddTypes(refVersion.Types())
-				locator = currLocator
-				ctx.SetResult(locator)
-				return
-			}
-		}
-	}
-
 	// Add the members:
 	membersCtxs := ctx.GetMembers()
 	if len(membersCtxs) > 0 {

--- a/pkg/language/reader.go
+++ b/pkg/language/reader.go
@@ -133,7 +133,7 @@ func (r *Reader) Read() (model *concepts.Model, err error) {
 	for _, service := range r.model.Services() {
 		for _, version := range service.Versions() {
 			for _, typ := range version.Types() {
-				if typ.Kind() != concepts.ListType {
+				if typ.Kind() != concepts.ListType && typ.Owner().Name() == version.Name() {
 					listName := names.Cat(typ.Name(), nomenclator.List)
 					listType := version.FindType(listName)
 					if listType == nil {
@@ -142,6 +142,10 @@ func (r *Reader) Read() (model *concepts.Model, err error) {
 						listType.SetName(listName)
 						listType.SetElement(typ)
 						version.AddType(listType)
+					} else {
+						// The list type was previously defined from a cross reference.
+						// we thus need to redefine it.
+						listType.SetOwner(version)
 					}
 				}
 			}
@@ -409,8 +413,16 @@ func (r *Reader) ExitClassDecl(ctx *ClassDeclContext) {
 		typ.SetKind(concepts.ClassType)
 		r.removeUndefinedType(typ)
 	} else {
-		r.reporter.Errorf("Type '%s' is already defined", name)
-		return
+		// we would like to override the owner of any previously defined types
+		// these might come from references.
+		// e.g.
+		//      @ref(name="/some/service/foo")
+		//      Class foo {
+		//         Bar Sometype
+		//      }
+		// some_type.model - an overriding decleration.
+		// Class SomeType {...}
+		typ.SetOwner(r.version)
 	}
 
 	// Add the documentation:
@@ -431,62 +443,60 @@ func (r *Reader) ExitClassDecl(ctx *ClassDeclContext) {
 	}
 
 	if path := annotations.ReferencePath(typ); path != "" {
-		if len(r.inputs) > 1 {
-			panic("refernced service with multiple inputs in undefined")
-		}
+		r.handleClassRef(typ, path)
+	}
+}
 
-		if r.service.Versions().Len() > 1 {
-			panic("cannot infer which version to add reference with multiple versions")
-		}
+func (r *Reader) handleClassRef(typ *concepts.Type, path string) {
+	if len(r.inputs) > 1 {
+		panic("referenced service with multiple inputs in undefined")
+	}
 
-		input := r.inputs[0]
-		currVersion := r.service.Versions()[0]
-		path = strings.TrimPrefix(path, "/")
-		components := strings.Split(path, "/")
-		referencedServiceName := components[0]
-		referencedVersion := components[1]
-		referencedType := components[2]
+	input := r.inputs[0]
+	path = strings.TrimPrefix(path, "/")
+	components := strings.Split(path, "/")
+	referencedServiceName := components[0]
+	referencedVersion := components[1]
+	referencedTypeName := components[2]
 
-		// Create an ad-hoc reader and model for the specific referenced service.
-		refReader := NewReader().
-			Reporter(r.reporter)
-		refReader.model = concepts.NewModel()
+	// Create an ad-hoc reader and model for the specific referenced service.
+	refReader := NewReader().
+		Reporter(r.reporter)
+	refReader.model = concepts.NewModel()
 
-		// Initialize the indexes of undefined concepts:
-		refReader.undefinedTypes = make(map[string]*concepts.Type)
-		refReader.undefinedResources = make(map[string]*concepts.Resource)
-		refReader.undefinedErrors = make(map[string]*concepts.Error)
+	// Initialize the indexes of undefined concepts:
+	refReader.undefinedTypes = make(map[string]*concepts.Type)
+	refReader.undefinedResources = make(map[string]*concepts.Resource)
+	refReader.undefinedErrors = make(map[string]*concepts.Error)
 
-		// load the ad-hoc service and version referenced and find the correct type.
-		refReader.loadService(fmt.Sprintf("%s/%s", input, referencedServiceName))
-		refVersion := refReader.service.FindVersion(names.ParseUsingSeparator(referencedVersion, "_"))
-		// Once loading the service, we find the reference type
-		// then recursively iterate the type tree and add the types to the current version.
-		for _, currType := range refVersion.Types() {
-			if strings.Compare(currType.Name().String(), referencedType) == 0 {
-				r.recursivelyAddTypeToVersion(currVersion, currType)
-			}
+	// load the ad-hoc service and version referenced and find the correct type.
+	refReader.loadService(fmt.Sprintf("%s/%s", input, referencedServiceName))
+	refVersion := refReader.service.FindVersion(names.ParseUsingSeparator(referencedVersion, "_"))
+	// Once loading the service, we find the reference type
+	// then recursively iterate the type tree and add the types to the current version.
+	for _, referencedType := range refVersion.Types() {
+		if strings.Compare(referencedType.Name().String(), referencedTypeName) == 0 {
+			r.recursivelyAddTypeToVersion(typ, referencedType)
 		}
 	}
 }
 
 // A helper function to recursively add types to a version
-func (r *Reader) recursivelyAddTypeToVersion(version *concepts.Version, typ *concepts.Type) {
-	var attributesToRemove concepts.AttributeSlice
-	for _, attribute := range typ.Attributes() {
-		// We wish to define links explicitly and not inherint them
-		// only the attribute fields.
-		if version.FindType(attribute.Type().Name()) == nil && !attribute.Link() {
-			r.recursivelyAddTypeToVersion(version, attribute.Type())
-		}
+func (r *Reader) recursivelyAddTypeToVersion(currType *concepts.Type,
+	referencedType *concepts.Type) {
+	for _, attribute := range referencedType.Attributes() {
 		if attribute.Link() {
-			attributesToRemove = append(attributesToRemove, attribute)
+			r.version.AddTypeWithoutOwner(attribute.Type())
+		}
+		if attribute.Type().IsList() || attribute.Type().IsMap() {
+			r.version.AddTypeWithoutOwner(attribute.Type())
+			r.version.AddTypeWithoutOwner(attribute.Type().Element())
+		}
+		if r.version.FindType(attribute.Type().Name()) == nil {
+			r.recursivelyAddTypeToVersion(currType, attribute.Type())
 		}
 	}
-	for _, attribute := range attributesToRemove {
-		typ.RemoveAttribute(attribute.Name())
-	}
-	version.AddType(typ)
+	r.version.AddType(referencedType)
 }
 
 func (r *Reader) ExitStructDecl(ctx *StructDeclContext) {

--- a/pkg/language/ref_test.go
+++ b/pkg/language/ref_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package language
+
+import (
+	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Read Model with ref annotation", func() {
+
+	It("Reads referenced class scalar attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				MyAttribute Integer
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		attribute := class.FindAttribute(names.ParseUsingCase("MyAttribute"))
+		Expect(attribute).ToNot(BeNil())
+		Expect(attribute.Type().Owner().Name().String()).To(Equal("v1"))
+	})
+
+	It("References respect link attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				link MyAttribute MyAttribute
+			}
+			`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		myAttribute := class.FindAttribute(names.ParseUsingCase("MyAttribute"))
+		Expect(myAttribute).ToNot(BeNil())
+		Expect(myAttribute.Type().Owner().Name().String()).To(Equal("v1"))
+		Expect(myAttribute.Link()).To(BeTrue())
+	})
+
+	It("Reads referenced class list attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				Foo []MyAttribute
+			}`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		attributeType := version.FindType(names.ParseUsingCase("MyAttribute"))
+		Expect(attributeType).ToNot(BeNil())
+		Expect(attributeType.Owner().Name().String()).To(Equal("v1_alpha1"))
+		attributeList := class.FindAttribute(names.ParseUsingCase("Foo"))
+		Expect(attributeList).ToNot(BeNil())
+		Expect(attributeList.Type().IsList()).To(BeTrue())
+		Expect(attributeList.Type().Owner().Name().String()).To(Equal("v1_alpha1"))
+	})
+
+	It("Overrides class with other class definition", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"my_service/v1_alpha1/my_attribute.model",
+			`
+			@ref(path="other_service/v1/my_attribute")
+			class MyAttribute {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				link Foo []MyAttribute
+			}`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+				Goo Bar
+			}
+			`,
+			"other_service/v1/bar.model",
+			`
+			class Bar {
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		Expect(class.Owner().Name().String()).To(Equal("v1_alpha1"))
+		attributeList := class.FindAttribute(names.ParseUsingCase("Foo"))
+		Expect(attributeList).ToNot(BeNil())
+		Expect(attributeList.Type().IsList()).To(BeTrue())
+		Expect(attributeList.Type().Owner().Name().String()).To(Equal("v1_alpha1"))
+		Expect(attributeList.Type().Element().Owner().Name().String()).To(Equal("v1_alpha1"))
+		barType := version.FindType(names.ParseUsingCase("Bar"))
+		Expect(barType.Owner().Name().String()).To(Equal("v1_alpha1"))
+	})
+})

--- a/pkg/language/ref_test.go
+++ b/pkg/language/ref_test.go
@@ -207,4 +207,188 @@ var _ = Describe("Read Model with ref annotation", func() {
 		barType := version.FindType(names.ParseUsingCase("Bar"))
 		Expect(barType.Owner().Name().String()).To(Equal("v1_alpha1"))
 	})
+
+	It("Overrides class with other class definition link attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"my_service/v1_alpha1/my_attribute.model",
+			`
+			@ref(path="other_service/v1/my_attribute")
+			class MyAttribute {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				link Foo []MyAttribute
+			}`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+				link Goo Bar
+			}
+			`,
+			"other_service/v1/bar.model",
+			`
+			class Bar {
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		Expect(class.Owner().Name().String()).To(Equal("v1_alpha1"))
+		attributeList := class.FindAttribute(names.ParseUsingCase("Foo"))
+		Expect(attributeList).ToNot(BeNil())
+		Expect(attributeList.Type().IsList()).To(BeTrue())
+		Expect(attributeList.Type().Owner().Name().String()).To(Equal("v1_alpha1"))
+		Expect(attributeList.Type().Element().Owner().Name().String()).To(Equal("v1_alpha1"))
+		myAttributeType := version.FindType(names.ParseUsingCase("MyAttribute"))
+		Expect(myAttributeType).ToNot(BeNil())
+		Expect(myAttributeType.Owner().Name().String()).To(Equal("v1_alpha1"))
+		barType := version.FindType(names.ParseUsingCase("Bar"))
+		// Referenced classes link doesn't change the owner
+		Expect(barType.Owner().Name().String()).To(Equal("v1"))
+	})
+
+	It("Overrides class with other class definition list attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"my_service/v1_alpha1/my_attribute.model",
+			`
+			@ref(path="other_service/v1/my_attribute")
+			class MyAttribute {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				link Foo []MyAttribute
+			}`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+				Goo []Bar
+			}
+			`,
+			"other_service/v1/bar.model",
+			`
+			class Bar {
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		Expect(class.Owner().Name().String()).To(Equal("v1_alpha1"))
+		attributeList := class.FindAttribute(names.ParseUsingCase("Foo"))
+		Expect(attributeList).ToNot(BeNil())
+		Expect(attributeList.Type().IsList()).To(BeTrue())
+		Expect(attributeList.Type().Owner().Name().String()).To(Equal("v1_alpha1"))
+		Expect(attributeList.Type().Element().Owner().Name().String()).To(Equal("v1_alpha1"))
+		myAttributeType := version.FindType(names.ParseUsingCase("MyAttribute"))
+		Expect(myAttributeType).ToNot(BeNil())
+		Expect(myAttributeType.Owner().Name().String()).To(Equal("v1_alpha1"))
+		barType := version.FindType(names.ParseUsingCase("Bar"))
+		Expect(barType.Owner().Name().String()).To(Equal("v1_alpha1"))
+	})
+
+	It("Overrides class with other class definition link list attribute", func() {
+		model := MakeModel(
+			"my_service/v1_alpha1/root.model",
+			`
+			resource Root {
+			}
+			`,
+			"my_service/v1_alpha1/my_class.model",
+			`
+			@ref(path="other_service/v1/my_class")
+			class MyClass {
+			}
+			`,
+			"my_service/v1_alpha1/my_attribute.model",
+			`
+			@ref(path="other_service/v1/my_attribute")
+			class MyAttribute {
+			}
+			`,
+			"other_service/v1/root.model",
+			`
+			resource Root{
+			}
+			`,
+			"other_service/v1/my_class.model",
+			`
+			class MyClass {
+				link Foo []MyAttribute
+			}`,
+			"other_service/v1/my_attribute.model",
+			`
+			class MyAttribute{
+				link Goo []Bar
+			}
+			`,
+			"other_service/v1/bar.model",
+			`
+			class Bar {
+			}
+			`,
+		)
+		// Check the attribute and its owner
+		service := model.FindService(names.ParseUsingSeparator("my_service", "_"))
+		Expect(service).ToNot(BeNil())
+		version := service.FindVersion(names.ParseUsingSeparator("v1_alpha1", "_"))
+		Expect(version).ToNot(BeNil())
+		class := version.FindType(names.ParseUsingCase("MyClass"))
+		Expect(class).ToNot(BeNil())
+		Expect(class.Owner().Name().String()).To(Equal("v1_alpha1"))
+		attributeList := class.FindAttribute(names.ParseUsingCase("Foo"))
+		Expect(attributeList).ToNot(BeNil())
+		Expect(attributeList.Type().IsList()).To(BeTrue())
+		Expect(attributeList.Type().Owner().Name().String()).To(Equal("v1_alpha1"))
+		Expect(attributeList.Type().Element().Owner().Name().String()).To(Equal("v1_alpha1"))
+		myAttributeType := version.FindType(names.ParseUsingCase("MyAttribute"))
+		Expect(myAttributeType).ToNot(BeNil())
+		Expect(myAttributeType.Owner().Name().String()).To(Equal("v1_alpha1"))
+		barType := version.FindType(names.ParseUsingCase("Bar"))
+		Expect(barType.Owner().Name().String()).To(Equal("v1"))
+	})
 })

--- a/tests/model/aro_hcp/v1_alpha1/cluster_resource.model
+++ b/tests/model/aro_hcp/v1_alpha1/cluster_resource.model
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific cluster.
+resource Cluster {
+	// Retrieves the details of the cluster.
+	method Get {
+		out Body Cluster
+	}
+
+	// Updates the cluster.
+	method Update {
+		in out Body Cluster
+	}
+
+	// Deletes the cluster.
+	method Delete {
+		// Dry run flag is used to check if the operation can be completed, but won't delete.
+		in DryRun Boolean = false
+
+		// BestEffort flag is used to check if the cluster deletion should be best-effort mode or not.
+		in BestEffort Boolean = false
+	}
+
+	// Reference to the resource that manages the collection of node pool resources.
+    locator NodePools {
+        target NodePools
+    }
+}

--- a/tests/model/aro_hcp/v1_alpha1/cluster_type.model
+++ b/tests/model/aro_hcp/v1_alpha1/cluster_type.model
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@ref(path = "/clusters_mgmt/v1/cluster")
+class Cluster {
+}

--- a/tests/model/aro_hcp/v1_alpha1/clusters_resource.model
+++ b/tests/model/aro_hcp/v1_alpha1/clusters_resource.model
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of aro_hcp clusters.
+resource Clusters {
+	// Retrieves the list of clusters.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Search criteria.
+		// 
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// clusters with a name starting with `my` in the `us-east-1` region the value
+		// should be:
+		//
+		// ```sql
+		// name like 'my%' and region.id = 'us-east-1'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// clusters that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to sort the clusters
+		// descending by region identifier the value should be:
+		//
+		// ```sql
+		// region.id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Retrieved list of clusters.
+		out Items []Cluster
+	}
+
+	// Provision a new cluster and add it to the collection of clusters.
+	// 
+	// See the `register_cluster` method for adding an existing cluster.
+	method Add {
+		// Description of the cluster.
+		in out Body Cluster
+	}
+
+	// Returns a reference to the service that manages an specific cluster.
+	locator Cluster {
+		target Cluster
+		variable ID
+	}
+}

--- a/tests/model/aro_hcp/v1_alpha1/node_pool_resource.model
+++ b/tests/model/aro_hcp/v1_alpha1/node_pool_resource.model
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific nodepool.
+resource NodePool {
+    // Retrieves the details of the node pool.
+    method Get {
+        out Body NodePool
+    }
+
+    // Updates the node pool.
+    method Update {
+        in out Body NodePool
+    }
+
+    // Deletes the node pool.
+    method Delete {
+    }
+}

--- a/tests/model/aro_hcp/v1_alpha1/node_pool_type.model
+++ b/tests/model/aro_hcp/v1_alpha1/node_pool_type.model
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@ref(path = "/clusters_mgmt/v1/node_pool")
+class NodePool {
+}

--- a/tests/model/aro_hcp/v1_alpha1/node_pools_resource.model
+++ b/tests/model/aro_hcp/v1_alpha1/node_pools_resource.model
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of node pools of a cluster.
+resource NodePools {
+	// Retrieves the list of node pools.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
+
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the node pools instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// node pools with replicas of two the following is required:
+		//
+		// ```sql
+		// replicas = 2
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// node pools that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the node pools instead of
+		// the names of the columns of a table. For example, in order to sort the node pools
+		// descending by identifier the value should be:
+		//
+		// ```sql
+		// id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of node pools.
+		out Items []NodePool
+	}
+
+	// Adds a new node pool to the cluster.
+	method Add {
+		// Description of the node pool
+		in out Body NodePool
+	}
+
+	// Reference to the service that manages a specific node pool.
+	locator NodePool {
+		target NodePool
+		variable ID
+	}
+}

--- a/tests/model/aro_hcp/v1_alpha1/root_resource.model
+++ b/tests/model/aro_hcp/v1_alpha1/root_resource.model
@@ -1,0 +1,18 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Root of the tree of resources of the aro_hcp service.
+resource Root {}

--- a/tests/model/clusters_mgmt/v1/node_pool_type.model
+++ b/tests/model/clusters_mgmt/v1/node_pool_type.model
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+Class NodePool {}


### PR DESCRIPTION
## What this does?
Adds support for a reference directive -  `@ref(name="/path/to/service")`  in order to share resources and definitions between services.

Currently this is only supported for types in order to share their definition between services, however, as we continue to implement the `/aro_hcp` service we will likely enhance this implementation.

[Here](https://github.com/openshift-online/ocm-api-model/pull/1006) is an example use case where we share the Cluster type:
```
@ref(path = "/clusters_mgmt/v1/cluster")
class Cluster {
}
```

With sdk that looks like the following:
```
It("Check for duplicate cluster name with same Azure Resource Name", func() {
	postBody, err := arohcphelper.GetAroHCPClusterBuilder(azureBuilder, westUs3, properties).Build()
	helper.CheckError(err)
	postResponse, err := connection.AroHCP().V1Alpha1().Clusters().Add().Body(postBody).SendContext(ctx)
	helper.CheckErrorResponse(postResponse, err, http.StatusBadRequest)
	Expect(postResponse.Error().Reason()).To(ContainSubstring("Duplicate ARO-HCP cluster"))
})
```

Important detail is that this preserves the "links" or references to other resources unless defined **explicitly**, for example:
```
func GetAroHCPClusterBuilder(azureBuilder *arohcp.AzureBuilder,
	region string, properties map[string]string) *arohcp.ClusterBuilder {
	return arohcp.NewCluster().
		Name(helper.GenerateClusterName()).
		Product(cmv1.NewProduct().ID(models.AROProductID)).
		CCS(arohcp.NewCCS().Enabled(true)).
		Region(cmv1.NewCloudRegion().ID(region)).
		Hypershift(arohcp.NewHypershift().Enabled(true)).
		MultiAZ(true).
		Azure(azureBuilder).
		Properties(properties)
}
```


From the docs [committed [here](https://github.com/openshift-online/ocm-api-model/pull/1006)]:

### Class references using @ref annotation
One can define a class reference inside a service such that it will inherit its content from
another service using the special `@ref` annotation, for example:

```
// In /aro_hcp/v1_alpha1/cluster_type.model
@ref(path = "/clusters_mgmt/v1/cluster")
class Cluster {
}
```

The above decelaration will inherit its content from the `Cluster` class under the `/clusters_mgmt/v1` service.
This means that any changes made in `Cluster` class will be reflected under this derived type as well.

Links to other resources are preserved as they are.

If one wishes to **override** a type she can create a class inside `/aro_hcp/v1_alpha1/` in order to override any nested types defined.
For example the following type declaration will override the `NodePools` link inside `Cluster` under `/aro_hcp/v1`:

```
// In /aro_hcp/v1_alpha1/node_pool_type.model
@ref(path = "/clusters_mgmt/v1/node_pool")
class NodePool {
}
```

This means that now under `Cluster` the `NodePools` field type is linked to the one defined in `/aro_hcp/v1_alpha1` (i.e. `v1alpha.NodePool`) which itself references and derived from the `NodePool` type under `/clusters_mgmt/v1`.