### PR TITLE
Update python github action to v5

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
There is an issue with the action that creates a new release.
https://github.com/openshift-online/ocm-api-metamodel/actions/runs/15412875097

```
 getCacheEntry failed: Request timeout: /OEMNWVcqUE5J3JpncaDxC0P3ZR3z1GQP9z7SrbhLzPkOCI6Pwi/_apis/artifactcache/cache?keys=setup-python-Linux-python-3.10.17-pip-5b8a201e3583bb0699a8a6aaa3671adf73af30e732b7160c2003440fd62dd132%2Csetup-python-Linux-python-3.10.17-pip&version=d344bb84502f06b0de8e98dde97f18085a2f23e88b59b4753659d9acc3e96934
```
According to this [issue](https://github.com/orgs/community/discussions/160793) it is recommended to keep the actions up to date.

> For others seeing this message, please ensure that your packages, and the dependencies of those packages, are all using an up-to-date version of the cache service.