### PR TITLE
feat: add support for asynchronous add and post methods

### DIFF
--- a/pkg/concepts/method.go
+++ b/pkg/concepts/method.go
@@ -81,6 +81,11 @@ func (m *Method) IsAdd() bool {
 	return m.name.Equals(nomenclator.Add)
 }
 
+// IsAsyncAdd return true if this is an asynchronous add method.
+func (m *Method) IsAsyncAdd() bool {
+	return m.name.Equals(nomenclator.AsyncAdd)
+}
+
 // IsDelete returns true if this is a delete method.
 func (m *Method) IsDelete() bool {
 	return m.name.Equals(nomenclator.Delete)
@@ -106,6 +111,11 @@ func (m *Method) IsPost() bool {
 	return m.name.Equals(nomenclator.Post)
 }
 
+// IsAsyncPost return true if this is an asynchronous post method.
+func (m *Method) IsAsyncPost() bool {
+	return m.name.Equals(nomenclator.AsyncPost)
+}
+
 // IsSearch returns true if this is a search method.
 func (m *Method) IsSearch() bool {
 	return m.name.Equals(nomenclator.Search)
@@ -126,6 +136,8 @@ func (m *Method) IsAction() bool {
 	switch {
 	case m.IsAdd():
 		return false
+	case m.IsAsyncAdd():
+		return false
 	case m.IsDelete():
 		return false
 	case m.IsAsyncDelete():
@@ -135,6 +147,8 @@ func (m *Method) IsAction() bool {
 	case m.IsList():
 		return false
 	case m.IsPost():
+		return false
+	case m.IsAsyncPost():
 		return false
 	case m.IsSearch():
 		return false

--- a/pkg/concepts/parameter.go
+++ b/pkg/concepts/parameter.go
@@ -89,7 +89,7 @@ func (p *Parameter) IsBody() bool {
 	if p.owner == nil {
 		return false
 	}
-	isRest := p.owner.IsAdd() || p.owner.IsGet() || p.owner.IsSearch() || p.owner.IsUpdate() || p.owner.IsAsyncUpdate()
+	isRest := p.owner.IsAdd() || p.owner.IsAsyncAdd() || p.owner.IsGet() || p.owner.IsSearch() || p.owner.IsUpdate() || p.owner.IsAsyncUpdate()
 	if isRest && p.name.Equals(nomenclator.Body) {
 		return true
 	}

--- a/pkg/generators/docs/docs_generator.go
+++ b/pkg/generators/docs/docs_generator.go
@@ -382,7 +382,7 @@ func (g *DocsGenerator) httpMethod(method *concepts.Method) string {
 	if name.Equals(nomenclator.Get) || name.Equals(nomenclator.List) {
 		return "GET"
 	}
-	if name.Equals(nomenclator.Add) {
+	if name.Equals(nomenclator.Add) || name.Equals(nomenclator.AsyncAdd) || name.Equals(nomenclator.Post) || name.Equals(nomenclator.AsyncPost) {
 		return "POST"
 	}
 	if name.Equals(nomenclator.Update) || name.Equals(nomenclator.AsyncUpdate) {

--- a/pkg/generators/golang/request_json_generator.go
+++ b/pkg/generators/golang/request_json_generator.go
@@ -450,7 +450,7 @@ func (g *RequestJSONSupportGenerator) generateResourceSupport(resource *concepts
 
 func (g *RequestJSONSupportGenerator) generateMethodSource(method *concepts.Method) {
 	switch {
-	case method.IsAdd():
+	case method.IsAdd() || method.IsAsyncAdd():
 		g.generateAddMethodSource(method)
 	case method.IsDelete() || method.IsAsyncDelete():
 		g.generateDeleteMethodSource(method)
@@ -458,7 +458,7 @@ func (g *RequestJSONSupportGenerator) generateMethodSource(method *concepts.Meth
 		g.generateGetMethodSource(method)
 	case method.IsList():
 		g.generateListMethodSource(method)
-	case method.IsPost():
+	case method.IsPost() || method.IsAsyncPost():
 		g.generatePostMethodSource(method)
 	case method.IsSearch():
 		g.generateSearchMethodSource(method)

--- a/pkg/http/binding_calculator.go
+++ b/pkg/http/binding_calculator.go
@@ -146,7 +146,7 @@ func (c *BindingCalculator) ResponseBodyParameters(method *concepts.Method) []*c
 func (c *BindingCalculator) Method(method *concepts.Method) string {
 	name := method.Name()
 	switch {
-	case name.Equals(nomenclator.Add):
+	case name.Equals(nomenclator.Add) || name.Equals(nomenclator.AsyncAdd):
 		return http.MethodPost
 	case name.Equals(nomenclator.Delete) || name.Equals(nomenclator.AsyncDelete):
 		return http.MethodDelete
@@ -154,7 +154,7 @@ func (c *BindingCalculator) Method(method *concepts.Method) string {
 		return http.MethodGet
 	case name.Equals(nomenclator.List):
 		return http.MethodGet
-	case name.Equals(nomenclator.Post):
+	case name.Equals(nomenclator.Post) || name.Equals(nomenclator.AsyncPost):
 		return http.MethodPost
 	case name.Equals(nomenclator.Update) || name.Equals(nomenclator.AsyncUpdate):
 		return http.MethodPatch
@@ -171,8 +171,12 @@ func (c *BindingCalculator) DefaultStatus(method *concepts.Method) string {
 	switch {
 	case name.Equals(nomenclator.Post):
 		status = http.StatusCreated
+	case name.Equals(nomenclator.AsyncPost):
+		status = http.StatusAccepted
 	case name.Equals(nomenclator.Add):
 		status = http.StatusCreated
+	case name.Equals(nomenclator.AsyncAdd):
+		status = http.StatusAccepted
 	case name.Equals(nomenclator.AsyncUpdate):
 		status = http.StatusAccepted
 	case name.Equals(nomenclator.Update):

--- a/pkg/language/checks.go
+++ b/pkg/language/checks.go
@@ -60,7 +60,7 @@ func (r *Reader) checkResource(resource *concepts.Resource) {
 func (r *Reader) checkMethod(method *concepts.Method) {
 	// Run specific checks according tot he type of method:
 	switch {
-	case method.IsAdd():
+	case method.IsAdd() || method.IsAsyncAdd():
 		r.checkAdd(method)
 	case method.IsDelete() || method.IsAsyncDelete():
 		r.checkDelete(method)
@@ -68,7 +68,7 @@ func (r *Reader) checkMethod(method *concepts.Method) {
 		r.checkGet(method)
 	case method.IsList():
 		r.checkList(method)
-	case method.IsPost():
+	case method.IsPost() || method.IsAsyncPost():
 		r.checkPost(method)
 	case method.IsSearch():
 		r.checkSearch(method)

--- a/pkg/nomenclator/names.go
+++ b/pkg/nomenclator/names.go
@@ -25,7 +25,9 @@ var (
 	Adapt       = names.ParseUsingCase("Adapt")
 	Adapter     = names.ParseUsingCase("Adapter")
 	Add         = names.ParseUsingCase("Add")
+	AsyncAdd    = names.ParseUsingCase("AsyncAdd")
 	AsyncDelete = names.ParseUsingCase("AsyncDelete")
+	AsyncPost   = names.ParseUsingCase("AsyncPost")
 	AsyncUpdate = names.ParseUsingCase("AsyncUpdate")
 
 	// B:


### PR DESCRIPTION
This follows on from PR  https://github.com/openshift-online/ocm-api-metamodel/pull/208 which added initial support for asynchronous methods `Delete` and `Update`.

This adds 2 new asynchronous methods for `Add` and `Post` which will be used for generating endpoints for v1alpha1 of the aro_hcp API (see https://github.com/openshift-online/ocm-api-model/pull/1047#discussion_r2140514241).