### PR TITLE
OWNERS file sanity

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,11 @@
-# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
-# Fetched from https://github.com/openshift-online/ocm-service-common root OWNERS
-# If the repo had OWNERS_ALIASES then the aliases were expanded
-# Logins who are not members of 'openshift' organization were filtered out
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mnecas
+- ahitacat
 - nimrodshn
 - vkareh
-- ahitacat
 reviewers:
-- mnecas
-- nimrodshn
 - ahitacat
+- nimrodshn
+emeritus_approvers:
+- mnecas # 2024


### PR DESCRIPTION
This commit:
- Removes mnecas from the approves/reviwers as @mnecas is no longer part of the team (:crying_cat_face: ). I have move him to emeritus_approvers section.
- Cleans unnecessary comments
