### PR TITLE
add @required annotation support for OpenAPI schema generation

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -70,6 +70,12 @@ func IsDeprecated(concept concepts.Annotated) bool {
 	return annotation != nil
 }
 
+// IsRequired checks if the given concept has a `required` annotation.
+func IsRequired(concept concepts.Annotated) bool {
+	annotation := concept.GetAnnotation("required")
+	return annotation != nil
+}
+
 // Reference checks if the given concept has a `reference` annotation. If it has it then it returns the value
 // of the `path` parameter. It returns an empty string if there is no such annotation or parameter.
 func ReferencePath(concept concepts.Annotated) string {

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -23,6 +23,79 @@ import (
 	"github.com/openshift-online/ocm-api-metamodel/pkg/names"
 )
 
+var _ = Describe("Required annotation support", func() {
+	Describe("IsRequired function", func() {
+		var annotatedConcept concepts.Annotated
+
+		BeforeEach(func() {
+			annotatedConcept = concepts.NewType()
+		})
+
+		Context("when concept has required annotation", func() {
+			It("should return true for required annotation without parameters", func() {
+				requiredAnnotation := concepts.NewAnnotation()
+				requiredAnnotation.SetName("required")
+				annotatedConcept.AddAnnotation(requiredAnnotation)
+
+				result := IsRequired(annotatedConcept)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true when required annotation exists among multiple annotations", func() {
+				jsonAnnotation := concepts.NewAnnotation()
+				jsonAnnotation.SetName("json")
+				annotatedConcept.AddAnnotation(jsonAnnotation)
+
+				requiredAnnotation := concepts.NewAnnotation()
+				requiredAnnotation.SetName("required")
+				annotatedConcept.AddAnnotation(requiredAnnotation)
+
+				result := IsRequired(annotatedConcept)
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when concept does not have required annotation", func() {
+			It("should return false for concept with no annotations", func() {
+				result := IsRequired(annotatedConcept)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false for concept with other annotations but no required", func() {
+				deprecatedAnnotation := concepts.NewAnnotation()
+				deprecatedAnnotation.SetName("deprecated")
+				annotatedConcept.AddAnnotation(deprecatedAnnotation)
+
+				result := IsRequired(annotatedConcept)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false for annotation with similar but different name", func() {
+				similarAnnotation := concepts.NewAnnotation()
+				similarAnnotation.SetName("requires")
+				annotatedConcept.AddAnnotation(similarAnnotation)
+
+				result := IsRequired(annotatedConcept)
+				Expect(result).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("Integration with different concept types", func() {
+		It("should work correctly with Attribute", func() {
+			attribute := concepts.NewAttribute()
+			attribute.SetName(names.ParseUsingCase("testAttribute"))
+
+			requiredAnnotation := concepts.NewAnnotation()
+			requiredAnnotation.SetName("required")
+			attribute.AddAnnotation(requiredAnnotation)
+
+			result := IsRequired(attribute)
+			Expect(result).To(BeTrue())
+		})
+	})
+})
+
 var _ = Describe("Deprecation annotation support", func() {
 	Describe("IsDeprecated function", func() {
 		var annotatedConcept concepts.Annotated

--- a/pkg/generators/openapi/openapi_generator.go
+++ b/pkg/generators/openapi/openapi_generator.go
@@ -542,6 +542,19 @@ func (g *OpenAPIGenerator) generateStructSchema(typ *concepts.Type) {
 		g.generateStructProperty(attribute)
 	}
 	g.buffer.EndObject()
+	var required []string
+	for _, attribute := range typ.Attributes() {
+		if annotations.IsRequired(attribute) {
+			required = append(required, g.names.AttributePropertyName(attribute))
+		}
+	}
+	if len(required) > 0 {
+		g.buffer.StartArray("required")
+		for _, name := range required {
+			g.buffer.Item(name)
+		}
+		g.buffer.EndArray()
+	}
 	g.buffer.EndObject()
 }
 


### PR DESCRIPTION
When a struct attribute has the @required annotation, the OpenAPI generator now emits a "required" array in the schema, enforcing field presence in the generated spec.